### PR TITLE
Fix ‘rip-off’ typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ferrisetw"
 version = "0.1.1"
 license = "MIT OR Apache-2.0"
-description = "Basically a rip off KrabsETW written in Rust"
+description = "Basically a KrabsETW rip-off written in Rust"
 authors = ["n4r1b"]
 edition = "2018"
 repository = "https://github.com/n4r1b/ferrisetw"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # FerrisETW 🦀
-**Basically a rip off [KrabsETW](https://github.com/microsoft/krabsetw/) written in Rust**, 
+**Basically a [KrabsETW](https://github.com/microsoft/krabsetw/) rip-off written in Rust**, 
 hence the name [`Ferris`](https://rustacean.net/) 🦀
 
 All **credits** go to the team at Microsoft who develop KrabsEtw, without it, this project 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! # Event Windows Tracing FTW!
-//! **Basically a rip off [KrabsETW] written in Rust**, hence the name `Ferris` 🦀
+//! **Basically a [KrabsETW] rip-off written in Rust**, hence the name `Ferris` 🦀
 //!
 //! All **credits** go to the team at Microsoft who develop KrabsEtw, without it, this project
 //! probably wouldn't be a thing.


### PR DESCRIPTION
‘rip off’ is a phrasal verb, ‘rip-off’ is a noun.  Similarly to how
‘set up’ is a phrasal verb and ‘setup’ is sa noun.