### PR TITLE
Allow cross-compilation with msvc-wine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1.2.1"
 # anyhow = "~1.0"
 
 [build-dependencies]
-windows = "0.9.1"
+windows_macros = "0.9.1"
 
 [lib]
 doctest = false

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::build!(
+    windows_macros::build!(
         Windows::Win32::Etw::*,
         Windows::Win32::Debug::WIN32_ERROR,
         Windows::Win32::SystemServices::{


### PR DESCRIPTION
Using the full windows crate as a build-dependencies makes it impossible to cross-compile ferrisetw from linux to windows, as the windows crate tries to link on kernel32.dll and other similar libs that don't exist on linux. By instead only relying on `windows_macros` in the build script, we can avoid this problem.