### PR TITLE
Fix: no longer using a pointer to a movable stack item

### DIFF
--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -87,7 +87,7 @@ impl NativeEtw {
 
     pub(crate) fn open(
         &mut self,
-        trace_data: &TraceData,
+        trace_data: &Box<TraceData>,
     ) -> EvntraceNativeResult<EventTraceLogfile> {
         self.open_trace(trace_data)
     }
@@ -149,7 +149,7 @@ impl NativeEtw {
         Ok(())
     }
 
-    fn open_trace(&mut self, trace_data: &TraceData) -> EvntraceNativeResult<EventTraceLogfile> {
+    fn open_trace(&mut self, trace_data: &Box<TraceData>) -> EvntraceNativeResult<EventTraceLogfile> {
         let mut log_file = EventTraceLogfile::create(trace_data, trace_callback_thunk);
 
         unsafe {

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -251,14 +251,18 @@ macro_rules! impl_base_trace {
 /// User Trace struct
 #[derive(Debug)]
 pub struct UserTrace {
-    data: TraceData,
+    // This is `Box`ed so that it does not move around the stack in case the `UserTrace` is moved
+    // This is important, because we give a pointer to it to Windows, so that it passes it back to us on callbacks
+    data: Box<TraceData>,
     etw: evntrace::NativeEtw,
 }
 
 /// Kernel Trace struct
 #[derive(Debug)]
 pub struct KernelTrace {
-    data: TraceData,
+    // This is `Box`ed so that it does not move around the stack in case the `UserTrace` is moved
+    // This is important, because we give a pointer to it to Windows, so that it passes it back to us on callbacks
+    data: Box<TraceData>,
     etw: evntrace::NativeEtw,
 }
 
@@ -288,7 +292,7 @@ pub trait TraceTrait: TraceBaseTrait {
 impl UserTrace {
     /// Create a UserTrace builder
     pub fn new() -> Self {
-        let data = TraceData::new();
+        let data = Box::new(TraceData::new());
         UserTrace {
             data,
             etw: evntrace::NativeEtw::new(),
@@ -299,7 +303,7 @@ impl UserTrace {
 impl KernelTrace {
     /// Create a KernelTrace builder
     pub fn new() -> Self {
-        let data = TraceData::new();
+        let data = Box::new(TraceData::new());
 
         let mut kt = KernelTrace {
             data,


### PR DESCRIPTION
We're feeding OpenTraceA with an EVENT_TRACE_LOGFILE, which contains (at least) two pointers:
* one to the callback, run on every ETW event This one points to a static location in code
* one to a `PVOID Context` that Windows will give back as argument of the callback This points at `UserTrace.data`, which previously lived on the stack. This means that moving the UserTrace (e.g. by returning it in a function result) would break the pointer. This is fixed by putting UserTrace.data on the heap. It is now the responsability of the ferrisetw developer (and not its user, who was unaware of it) to *not* move it.

This changes the public API, so this means this should be released as a new major number of this crate

Refs #18