### PR TITLE
[API] Using a more explicit as_mut_ptr()

### DIFF
--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -212,25 +212,20 @@ impl<'tracedata> EventTraceLogfile<'tracedata> {
 
         log_file
     }
+
+    /// Retrieve the windows-rs compatible pointer to the contained `EVENT_TRACE_LOGFILEA`
+    ///
+    /// # Safety
+    ///
+    /// This pointer is valid as long as [`Self`] is alive (and not modified elsewhere)
+    pub unsafe fn as_mut_ptr(&mut self) -> *mut Etw::EVENT_TRACE_LOGFILEA {
+        &mut self.native as *mut Etw::EVENT_TRACE_LOGFILEA
+    }
 }
 
 impl<'tracedata> Default for EventTraceLogfile<'tracedata> {
     fn default() -> Self {
         unsafe { std::mem::zeroed::<EventTraceLogfile>() }
-    }
-}
-
-impl<'tracedata> std::ops::Deref for EventTraceLogfile<'tracedata> {
-    type Target = Etw::EVENT_TRACE_LOGFILEA;
-
-    fn deref(&self) -> &self::Etw::EVENT_TRACE_LOGFILEA {
-        &self.native
-    }
-}
-
-impl<'tracedata> std::ops::DerefMut for EventTraceLogfile<'tracedata> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.native
     }
 }
 

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -153,7 +153,7 @@ impl NativeEtw {
         let mut log_file = EventTraceLogfile::create(trace_data, trace_callback_thunk);
 
         unsafe {
-            self.session_handle = Etw::OpenTraceA(&mut *log_file);
+            self.session_handle = Etw::OpenTraceA(log_file.as_mut_ptr());
             if self.session_handle == INVALID_TRACE_HANDLE {
                 return Err(EvntraceNativeError::IoError(std::io::Error::last_os_error()));
             }


### PR DESCRIPTION
That's a bit of a nitpick, but that's slightly more idiomatic this way (and we have a slightly better doc + have the compiler enforces that's an `unsafe` function).