### PR TITLE
Provider filters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@
 //!     let process_provider = Provider::new()
 //!         .by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
 //!         .add_callback(process_callback)
+//!         // .add_filter(event_filters) // it is possible to filter by event ID, process ID, etc.
 //!         .build()
 //!         .unwrap();
 //!

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -7,6 +7,7 @@
 //! In most cases a user of the crate won't have to deal with this and can directly obtain the data
 //! needed by using the functions exposed by the modules at the crate level
 use crate::native::tdh_types::Property;
+use crate::provider::event_filter::EventFilterDescriptor;
 use crate::provider::{Provider, TraceFlags};
 use crate::trace::{TraceData, TraceProperties, TraceTrait};
 use crate::utils;
@@ -18,6 +19,7 @@ use windows::core::GUID;
 use windows::core::PSTR;
 use windows::Win32::Foundation::MAX_PATH;
 use windows::Win32::System::Diagnostics::Etw;
+use windows::Win32::System::Diagnostics::Etw::EVENT_FILTER_DESCRIPTOR;
 
 // typedef ULONG64 TRACEHANDLE, *PTRACEHANDLE;
 pub(crate) type TraceHandle = u64;
@@ -239,37 +241,44 @@ impl<'tracedata> std::ops::DerefMut for EventTraceLogfile<'tracedata> {
 /// [ENABLE_TRACE_PARAMETERS]: https://microsoft.github.io/windows-docs-rs/doc/bindings/Windows/Win32/Etw/struct.ENABLE_TRACE_PARAMETERS.html
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
-pub struct EnableTraceParameters(Etw::ENABLE_TRACE_PARAMETERS);
+pub struct EnableTraceParameters<'filters>{
+    native: Etw::ENABLE_TRACE_PARAMETERS,
+    lifetime: PhantomData<&'filters EventFilterDescriptor>,
+}
 
-impl EnableTraceParameters {
-    pub fn create(guid: GUID, trace_flags: TraceFlags) -> Self {
+impl<'filters> EnableTraceParameters<'filters> {
+    pub fn create(guid: GUID, trace_flags: TraceFlags, filters: &'filters [EventFilterDescriptor]) -> Self {
         let mut params = EnableTraceParameters::default();
-        params.0.ControlFlags = 0;
-        params.0.Version = Etw::ENABLE_TRACE_PARAMETERS_VERSION_2;
-        params.0.SourceId = guid;
-        params.0.EnableProperty = trace_flags.bits();
+        params.native.ControlFlags = 0;
+        params.native.Version = Etw::ENABLE_TRACE_PARAMETERS_VERSION_2;
+        params.native.SourceId = guid;
+        params.native.EnableProperty = trace_flags.bits();
 
-        // TODO: Add Filters option
-        params.0.EnableFilterDesc = std::ptr::null_mut();
-        params.0.FilterDescCount = 0;
+
+        let mut win_filter_descriptors: Vec<EVENT_FILTER_DESCRIPTOR> = filters
+            .iter()
+            .map(|efd| efd.as_event_filter_descriptor())
+            .collect();
+        params.native.FilterDescCount = win_filter_descriptors.len() as u32; // (let's assume we won't try to fit more than 4 billion filters)
+        if filters.is_empty() {
+            params.native.EnableFilterDesc = std::ptr::null_mut();
+        } else {
+            params.native.EnableFilterDesc = win_filter_descriptors.as_mut_ptr();
+        }
 
         params
     }
-}
 
-impl std::ops::Deref for EnableTraceParameters {
-    type Target = Etw::ENABLE_TRACE_PARAMETERS;
-
-    fn deref(&self) -> &self::Etw::ENABLE_TRACE_PARAMETERS {
-        &self.0
+    /// Returns an unsafe pointer over the wrapped `ENABLE_TRACE_PARAMETERS`
+    ///
+    /// # Safety
+    ///
+    /// This pointer is valid as long `self` is valid (and not mutated)
+    pub fn as_ptr(&self) -> *const Etw::ENABLE_TRACE_PARAMETERS {
+        &self.native as *const _
     }
 }
 
-impl std::ops::DerefMut for EnableTraceParameters {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 /// Newtype wrapper over an [TRACE_EVENT_INFO]
 ///

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -14,7 +14,6 @@ use crate::utils;
 use std::ffi::c_void;
 use std::fmt::Formatter;
 use std::marker::PhantomData;
-use std::sync::RwLock;
 use windows::core::GUID;
 use windows::core::PSTR;
 use windows::Win32::Foundation::MAX_PATH;
@@ -148,7 +147,7 @@ impl TraceInfo {
         &mut self,
         trace_name: &str,
         trace_properties: &TraceProperties,
-        providers: &RwLock<Vec<Provider>>,
+        providers: &[Provider],
     ) where
         T: TraceTrait,
     {

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -18,7 +18,6 @@ use super::etw_types::*;
 use crate::provider::Provider;
 use crate::trace::{TraceData, TraceProperties, TraceTrait};
 use crate::traits::*;
-use std::sync::RwLock;
 
 /// Evntrace native module errors
 #[derive(Debug)]
@@ -71,7 +70,7 @@ impl NativeEtw {
         &mut self,
         name: &str,
         properties: &TraceProperties,
-        providers: &RwLock<Vec<Provider>>,
+        providers: &[Provider],
     ) where
         T: TraceTrait,
     {

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -228,7 +228,7 @@ impl NativeEtw {
                 any,
                 all,
                 0,
-                &*parameters,
+                parameters.as_ptr(),
             ) != 0
             {
                 return Err(EvntraceNativeError::IoError(std::io::Error::last_os_error()));

--- a/src/provider/event_filter.rs
+++ b/src/provider/event_filter.rs
@@ -1,0 +1,172 @@
+use std::alloc::Layout;
+use std::error::Error;
+
+use windows::Win32::Foundation::BOOLEAN;
+use windows::Win32::System::Diagnostics::Etw::{EVENT_FILTER_DESCRIPTOR, EVENT_FILTER_TYPE_PID, EVENT_FILTER_TYPE_EVENT_ID, EVENT_FILTER_EVENT_ID};
+use windows::Win32::System::Diagnostics::Etw::{MAX_EVENT_FILTER_EVENT_ID_COUNT, MAX_EVENT_FILTER_PID_COUNT};
+
+/// Specifies how this provider will filter its events
+pub enum EventFilter {
+    /// Filter by PID.
+    /// This is only effective on kernel mode logger session.
+    ByPids(Vec<u16>),
+    /// Filter by ETW Event ID.
+    ByEventIds(Vec<u16>),
+    // TODO: see https://docs.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_filter_descriptor
+    //       and https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-enabletraceex2#remarks
+    //       other filter types are possible
+    //       I'm not always sure what they mean though
+}
+
+impl EventFilter {
+    /// Builds an EventFilterDescriptor (which can in turn generate an EVENT_FILTER_DESCRIPTOR)
+    pub(crate) fn to_event_filter_descriptor(&self) -> Result<EventFilterDescriptor, Box<dyn Error>> {
+        match self {
+            EventFilter::ByPids(pids) => EventFilterDescriptor::try_new_by_process_ids(&pids),
+            EventFilter::ByEventIds(ids) => EventFilterDescriptor::try_new_by_event_ids(&ids),
+        }
+    }
+}
+
+/// Similar to windows' `EVENT_FILTER_DESCRIPTOR`, but with owned data
+///
+/// See [`Self::as_event_filter_descriptor`] to get a Windows-rs-compatible type
+#[derive(Debug)]
+pub struct EventFilterDescriptor {
+    data: *mut u8,
+    layout: Layout,
+    ty: u32,
+}
+
+impl EventFilterDescriptor {
+    /// Allocates a new instance, where the included data is `data_size` bytes, and is suitably aligned for type `T`
+    fn try_new<T>(data_size: usize) -> Result<Self, Box<dyn Error>> {
+        let data_size = match data_size {
+            0 => return Err("Filter must not be empty".into()),
+            1..=1024 => data_size as u32,
+            _ => {
+                // See https://docs.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_filter_descriptor
+                return Err("Exceeded filter size limits".into())
+            },
+        };
+
+        let layout = Layout::from_size_align(data_size as usize, std::mem::align_of::<T>())?;
+        let data = unsafe {
+            // Safety: layout size is non-zero
+            std::alloc::alloc(layout)
+        };
+        if data.is_null() {
+            return Err("Invalid allocation".into());
+        }
+        Ok(Self { data, layout, ty: 0 })
+    }
+
+    /// Build a new instance that will filter by event ID.
+    ///
+    /// Returns an `Err` in case the allocation failed, or if either zero or too many filter items were given
+    pub fn try_new_by_event_ids(eids: &[u16]) -> Result<Self, Box<dyn Error>> {
+        if eids.len() > MAX_EVENT_FILTER_EVENT_ID_COUNT as usize {
+            // See https://docs.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_filter_descriptor
+            return Err("Too many event IDs are filtered".into());
+        }
+
+        let data_size = std::mem::size_of::<EVENT_FILTER_EVENT_ID>() + (
+            (eids.len().saturating_sub(1)) * std::mem::size_of::<u16>()
+        );
+        let mut s = Self::try_new::<EVENT_FILTER_EVENT_ID>(data_size)?;
+        s.ty = EVENT_FILTER_TYPE_EVENT_ID;
+
+        // Fill the data with an array of `EVENT_FILTER_EVENT_ID`s
+        let p = s.data.cast::<EVENT_FILTER_EVENT_ID>();
+        let mut p_evt = unsafe {
+            (*p).FilterIn = BOOLEAN(1);
+            (*p).Reserved = 0;
+            (*p).Count = eids.len() as u16; // we've checked the array was less than 1024 items
+            &((*p).Events[0]) as *const u16 as *mut u16
+        };
+        if eids.is_empty() {
+            // Just to avoid an unintialized data, but should never be accessed anyway since p->Count = 0
+            unsafe{
+                *p_evt = 0;
+            };
+            return Ok(s);
+        }
+
+        for event_id in eids {
+            unsafe{
+                *p_evt = *event_id;
+            };
+
+            p_evt = unsafe {
+                // Safety:
+                // * both the starting and resulting pointer are within the same allocated object
+                //   (except for the very last item, but that will not be written to)
+                // * thus, the offset is smaller than an isize
+                p_evt.offset(1)
+            };
+        }
+
+        Ok(s)
+    }
+
+    /// Build a new instance that will filter by PIDs.
+    ///
+    /// Returns an `Err` in case the allocation failed, or if either zero or too many filter items were given
+    pub fn try_new_by_process_ids(pids: &[u16]) -> Result<Self, Box<dyn Error>> {
+        if pids.len() > MAX_EVENT_FILTER_PID_COUNT as usize {
+            // See https://docs.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_filter_descriptor
+            return Err("Too many PIDs are filtered".into());
+        }
+
+        let data_size = pids.len() * std::mem::size_of::<u16>(); // PIDs are WORD, i.e. 16bits
+
+        let mut s = Self::try_new::<u16>(data_size)?;
+        s.ty = EVENT_FILTER_TYPE_PID;
+
+        if pids.is_empty() {
+            s.data = std::ptr::null_mut();
+        } else {
+            let mut p = s.data.cast::<u16>();
+            for pid in pids {
+                unsafe{
+                    *p = *pid;
+                };
+
+                p = unsafe {
+                    // Safety:
+                    // * both the starting and resulting pointer are within the same allocated object
+                    //   (except for the very last item, but that will not be written to)
+                    // * thus, the offset is smaller than an isize
+                    p.offset(1)
+                };
+            }
+        }
+
+        Ok(s)
+    }
+
+    /// Returns the EVENT_FILTER_DESCRIPTOR from this [`EventFilterDescriptor`]
+    ///
+    /// # Safety
+    ///
+    /// This will often be fed to an unsafe Windows function (e.g. [EnableTraceEx2](https://docs.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-enabletraceex2)).
+    /// Note that this contains pointers to the current `EventFilterDescriptor`, that must remain valid until the called function is done.
+    pub fn as_event_filter_descriptor(&self) -> EVENT_FILTER_DESCRIPTOR {
+        EVENT_FILTER_DESCRIPTOR {
+            Ptr: self.data as u64,
+            Size: self.layout.size() as u32,
+            Type: self.ty,
+        }
+    }
+}
+
+impl Drop for EventFilterDescriptor {
+    fn drop(&mut self) {
+        unsafe{
+            // Safety:
+            // * ptr is a block of memory currently allocated via alloc::alloc
+            // * layout is th one that was used to allocate that block of memory
+            std::alloc::dealloc(self.data, self.layout);
+        }
+    }
+}


### PR DESCRIPTION
This adds the ability to filter events per PID, or per Event ID:

```rust
use ferrisetw::provider::{EventFilter, Provider};

let only_events_18_or_42 = EventFilter::ByEventIds(vec![18, 42]);
let only_pid_1234 = EventFilter::ByPids(vec![1234]);

Provider::new()
    .add_filter(only_events_18_or_42)
    .add_filter(only_pid_1234);
```

I wished I could add an integration test, but really that's complex, flaky and long to run, so I gave up.
I'll add simple integration tests in another MR though.