### PR TITLE
GitHub actions on doc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ env:
 jobs:
   build-and-test:
     runs-on: windows-2022
+    # Necessary so that doc issues (warnings) are catched as hard errors
+    env:
+      RUSTDOCFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
@@ -19,12 +22,20 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    # Cargo check
     - uses: actions-rs/cargo@v1
       with:
         command: check
+    # Cargo doc
+    - uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-deps
+    # Cargo test
     - uses: actions-rs/cargo@v1
       with:
         command: test
+    # Cargo test (for the doctests only)
     - uses: actions-rs/cargo@v1
       with:
         command: test

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -81,7 +81,7 @@ impl SchemaKey {
 /// * EventHeader.EventDescriptor.Level
 ///
 /// Credits: [KrabsETW::schema_locator](https://github.com/microsoft/krabsetw/blob/master/krabs/krabs/schema_locator.hpp).
-/// See also the [`SchemaKey`] for more info
+/// See also the code of `SchemaKey` for more info
 #[derive(Default)]
 pub struct SchemaLocator {
     schemas: HashMap<SchemaKey, Arc<TraceEventInfoRaw>>,


### PR DESCRIPTION
This will catch errors on the documentation, and make sure upcoming releases will have their doc hosted on `docs.rs`