### PR TITLE
[minor] Used a more suited bitflags API

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -140,7 +140,7 @@ impl<'schema, 'record> Parser<'schema, 'record> {
 
         if property
             .flags
-            .intersects(PropertyFlags::PROPERTY_PARAM_LENGTH) == false
+            .contains(PropertyFlags::PROPERTY_PARAM_LENGTH) == false
             && (property.len() > 0)
         {
             let size = if property.in_type() != TdhInType::InTypePointer {


### PR DESCRIPTION
`intersects` was working because it compared to a 1-bit value. But what we really want is `contains` here