### PR TITLE
Improved schema locator

### DIFF
--- a/examples/kernel_trace.rs
+++ b/examples/kernel_trace.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 fn main() {
     let image_load_callback =
-        |record: &EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
+        |record: &EventRecord, schema_locator: &SchemaLocator| match schema_locator
             .event_schema(record)
         {
             Ok(schema) => {

--- a/examples/multiple_providers.rs
+++ b/examples/multiple_providers.rs
@@ -6,7 +6,7 @@ use ferrisetw::trace::*;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
-fn registry_callback(record: &EventRecord, schema_locator: &mut SchemaLocator) {
+fn registry_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
     match schema_locator.event_schema(record) {
         Ok(schema) => {
             if record.event_id() == 7 {
@@ -25,7 +25,7 @@ fn registry_callback(record: &EventRecord, schema_locator: &mut SchemaLocator) {
     };
 }
 
-fn tcpip_callback(record: &EventRecord, schema_locator: &mut SchemaLocator) {
+fn tcpip_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
     match schema_locator.event_schema(record) {
         Ok(schema) => {
             if record.event_id() == 11 {

--- a/examples/user_trace.rs
+++ b/examples/user_trace.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 fn main() {
     let process_callback =
-        |record: &EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
+        |record: &EventRecord, schema_locator: &SchemaLocator| match schema_locator
             .event_schema(record)
         {
             Ok(schema) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! use ferrisetw::provider::Provider;
 //! use ferrisetw::trace::{UserTrace, TraceTrait, TraceBaseTrait};
 //!
-//! fn process_callback(record: &EventRecord, schema_locator: &mut SchemaLocator) {
+//! fn process_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
 //!     // Within the callback we first locate the proper Schema for the event
 //!     match schema_locator.event_schema(record) {
 //!         Ok(schema) => {

--- a/src/native/etw_types/event_record.rs
+++ b/src/native/etw_types/event_record.rs
@@ -107,7 +107,7 @@ impl EventRecord {
     /// # use ferrisetw::schema_locator::SchemaLocator;
     /// use windows::Win32::System::Diagnostics::Etw::EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID;
     ///
-    /// let my_callback = |record: &EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let activity_id = record
     ///         .extended_data()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,7 +116,7 @@ impl<'schema, 'record> Parser<'schema, 'record> {
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema_locator::SchemaLocator;
     /// # use ferrisetw::parser::Parser;
-    /// let my_callback = |record: &EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let parser = Parser::create(record, &schema);
     /// };
@@ -252,7 +252,7 @@ impl_try_parse_primitive!(isize);
 /// # use ferrisetw::native::etw_types::EventRecord;
 /// # use ferrisetw::schema_locator::SchemaLocator;
 /// # use ferrisetw::parser::{Parser, TryParse};
-/// let my_callback = |record: &EventRecord, schema_locator: &mut SchemaLocator| {
+/// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
 ///     let schema = schema_locator.event_schema(record).unwrap();
 ///     let mut parser = Parser::create(record, &schema);
 ///     let image_name: String = parser.try_parse("ImageName").unwrap();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,7 +4,6 @@
 use crate::native::etw_types::DecodingSource;
 use crate::native::tdh::TraceEventInfo;
 use crate::native::tdh_types::Property;
-use std::sync::Arc;
 use once_cell::sync::OnceCell;
 
 /// A schema suitable for parsing a given kind of event.
@@ -14,12 +13,12 @@ use once_cell::sync::OnceCell;
 /// This structure is basically a wrapper over a [TraceEventInfo](https://docs.microsoft.com/en-us/windows/win32/api/tdh/ns-tdh-trace_event_info),
 /// with a few info parsed (and cached) out of it
 pub struct Schema {
-    te_info: Arc<TraceEventInfo>,
+    te_info: TraceEventInfo,
     cached_properties: OnceCell<Vec<Property>>,
 }
 
 impl Schema {
-    pub(crate) fn new(te_info: Arc<TraceEventInfo>) -> Self {
+    pub(crate) fn new(te_info: TraceEventInfo) -> Self {
         Schema {
             te_info,
             cached_properties: OnceCell::new()
@@ -36,7 +35,7 @@ impl Schema {
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema_locator::SchemaLocator;
 
-    /// let my_callback = |record: &EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let decoding_source = schema.decoding_source();
     /// };
@@ -52,7 +51,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema_locator::SchemaLocator;
-    /// let my_callback = |record: &EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let provider_name = schema.provider_name();
     /// };
@@ -69,7 +68,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema_locator::SchemaLocator;
-    /// let my_callback = |record: &EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let task_name = schema.task_name();
     /// };
@@ -86,7 +85,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema_locator::SchemaLocator;
-    /// let my_callback = |record: &EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let opcode_name = schema.opcode_name();
     /// };

--- a/src/schema_locator.rs
+++ b/src/schema_locator.rs
@@ -82,8 +82,10 @@ pub struct SchemaLocator {
 }
 
 impl std::fmt::Debug for SchemaLocator {
-    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SchemaLocator")
+            .field("len", &self.schemas.try_lock().map(|guard| guard.len()))
+            .finish()
     }
 }
 

--- a/src/schema_locator.rs
+++ b/src/schema_locator.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use windows::core::GUID;
+
 use crate::native::tdh;
 use crate::native::tdh::TraceEventInfo;
 use crate::native::etw_types::EventRecord;
@@ -32,9 +34,7 @@ type SchemaResult<T> = Result<T, SchemaError>;
 /// > i.e. all events with the same DecodeGuid, Id, and Version should have the same set of fields with no changes in field names, field types, or field ordering.
 #[derive(Debug, Eq, PartialEq, Hash)]
 struct SchemaKey {
-    // For now, lazy to wrap Guid around an implement Hash
-    // TODO: wrap Guid and implement hash
-    provider: String,
+    provider: GUID,
     /// From the [docs](https://docs.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_descriptor): A 16-bit number used to identify manifest-based events
     id: u16,
     /// From the [docs](https://docs.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_descriptor): An 8-bit number used to specify the version of a manifest-based event.
@@ -54,9 +54,8 @@ struct SchemaKey {
 
 impl SchemaKey {
     pub fn new(event: &EventRecord) -> Self {
-        let provider = format!("{:?}", event.provider_id());
         SchemaKey {
-            provider,
+            provider: event.provider_id(),
             id: event.event_id(),
             opcode: event.opcode(),
             version: event.version(),


### PR DESCRIPTION
* SchemaLocator has interior mutability
This will make it easier to use across various threads

* Simplified SchemaKey
Because windows-rs::core::GUID now implements `Hash`
This probably improves the perfs of ferrisetw a bit