### PR TITLE
A bunch of changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ env:
 jobs:
   build-and-test:
     runs-on: windows-2022
+    # Necessary so that doc issues (warnings) are catched as hard errors
+    env:
+      RUSTDOCFLAGS: -D warnings
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
@@ -19,12 +22,20 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    # Cargo check
     - uses: actions-rs/cargo@v1
       with:
         command: check
+    # Cargo doc
+    - uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-deps
+    # Cargo test
     - uses: actions-rs/cargo@v1
       with:
         command: test
+    # Cargo test (for the doctests only)
     - uses: actions-rs/cargo@v1
       with:
         command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 bitflags = "1.3.2"
 zerocopy = "0.6.1"
+widestring = "1.0.2"
 # thiserror = "~1.0"
 # anyhow = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ num = "0.4"
 num-traits = "0.2"
 num-derive = "0.3"
 bitflags = "1.3.2"
+zerocopy = "0.6.1"
 # thiserror = "~1.0"
 # anyhow = "~1.0"
 

--- a/examples/kernel_stack.rs
+++ b/examples/kernel_stack.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 fn main() {
     let profile_callback =
-        |record: EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
+        |record: &mut EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
             .event_schema(record)
         {
             Ok(schema) => {

--- a/examples/kernel_trace.rs
+++ b/examples/kernel_trace.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 fn main() {
     let image_load_callback =
-        |record: EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
+        |record: &mut EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
             .event_schema(record)
         {
             Ok(schema) => {

--- a/examples/multiple_providers.rs
+++ b/examples/multiple_providers.rs
@@ -7,7 +7,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::Duration;
 
-fn registry_callback(record: EventRecord, schema_locator: &mut SchemaLocator) {
+fn registry_callback(record: &mut EventRecord, schema_locator: &mut SchemaLocator) {
     match schema_locator.event_schema(record) {
         Ok(schema) => {
             if schema.event_id() == 7 {
@@ -26,7 +26,7 @@ fn registry_callback(record: EventRecord, schema_locator: &mut SchemaLocator) {
     };
 }
 
-fn tcpip_callback(record: EventRecord, schema_locator: &mut SchemaLocator) {
+fn tcpip_callback(record: &mut EventRecord, schema_locator: &mut SchemaLocator) {
     match schema_locator.event_schema(record) {
         Ok(schema) => {
             if schema.event_id() == 11 {

--- a/examples/sys_info.rs
+++ b/examples/sys_info.rs
@@ -1,0 +1,9 @@
+use ferrisetw::query::*;
+
+fn main() {
+    println!("Max PMC: {}", SessionlessInfo::max_pmc().unwrap());
+    println!(
+        "Profile Interval: {}",
+        SessionlessInfo::sample_interval(ProfileSource::ProfileTime).unwrap()
+    );
+}

--- a/examples/sys_info.rs
+++ b/examples/sys_info.rs
@@ -6,4 +6,13 @@ fn main() {
         "Profile Interval: {}",
         SessionlessInfo::sample_interval(ProfileSource::ProfileTime).unwrap()
     );
+
+    let sources = SessionlessInfo::profile_sources().unwrap();
+    println!("Profile Sources:");
+    for source in sources {
+        println!(
+            "  {:<32}: {:02} [{}-{}]",
+            source.description, source.id, source.min_interval, source.max_interval
+        );
+    }
 }

--- a/examples/user_trace.rs
+++ b/examples/user_trace.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 fn main() {
     let process_callback =
-        |record: EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
+        |record: &mut EventRecord, schema_locator: &mut SchemaLocator| match schema_locator
             .event_schema(record)
         {
             Ok(schema) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ pub mod native;
 pub mod parser;
 pub mod property;
 pub mod provider;
+pub mod query;
 pub mod schema;
 pub mod trace;
 mod traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! use ferrisetw::parser::Parser;
 //! use ferrisetw::parser::TryParse;
 //! use ferrisetw::provider::Provider;
-//! use ferrisetw::trace::{UserTraceBuilder, TraceTrait, TraceBaseTrait};
+//! use ferrisetw::trace::{UserTraceBuilder, TraceTrait};
 //! use std::sync::Arc;
 //!
 //! fn process_callback(record: &mut EventRecord, schema_locator: &mut SchemaLocator) {

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -29,6 +29,45 @@ pub(crate) type PEventRecord = *mut EventRecord;
 
 pub const INVALID_TRACE_HANDLE: TraceHandle = u64::MAX;
 
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+#[repr(i32)]
+pub enum TraceInformation {
+    TraceGuidQueryList,
+    TraceGuidQueryInfo,
+    TraceGuidQueryProcess,
+    TraceStackTracingInfo,
+    TraceSystemTraceEnableFlagsInfo,
+    TraceSampledProfileIntervalInfo,
+    TraceProfileSourceConfigInfo,
+    TraceProfileSourceListInfo,
+    TracePmcEventListInfo,
+    TracePmcCounterListInfo,
+    TraceSetDisallowList,
+    TraceVersionInfo,
+    TraceGroupQueryList,
+    TraceGroupQueryInfo,
+    TraceDisallowListQuery,
+    TraceInfoReserved15,
+    TracePeriodicCaptureStateListInfo,
+    TracePeriodicCaptureStateInfo,
+    TraceProviderBinaryTracking,
+    TraceMaxLoggersQuery,
+    TraceLbrConfigurationInfo,
+    TraceLbrEventListInfo,
+    /// Query the maximum PMC counters that can be specified simultaneously.
+    /// May be queried without an active ETW session.
+    ///
+    /// Output: u32
+    TraceMaxPmcCounterQuery,
+    TraceStreamCount,
+    TraceStackCachingInfo,
+    TracePmcCounterOwners,
+    TraceUnifiedStackCachingInfo,
+    TracePmcSessionInformation,
+    MaxTraceSetInfoClass,
+}
+
 #[allow(dead_code)]
 pub(crate) enum ControlValues {
     Query = 0,
@@ -196,7 +235,10 @@ impl EventTraceLogfile {
     /// # Safety
     ///
     /// Note that the returned structure contains pointers to the given `TraceData`, that should thus stay valid (and constant) during its lifetime
-    pub fn create(trace_data: &TraceData, callback: unsafe extern "system" fn(*mut EventRecord)) -> Self {
+    pub fn create(
+        trace_data: &TraceData,
+        callback: unsafe extern "system" fn(*mut EventRecord),
+    ) -> Self {
         let mut log_file = EventTraceLogfile::default();
 
         let not_really_mut_ptr = trace_data.name.as_ptr() as *mut _; // That's kind-of fine because the logger name is _not supposed_ to be changed by Windows APIs

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -11,7 +11,6 @@ use crate::provider::Provider;
 use crate::trace::{TraceData, TraceProperties, TraceTrait};
 use crate::utils;
 use std::fmt::Formatter;
-use std::sync::RwLock;
 use windows::core::GUID;
 use windows::core::PSTR;
 use windows::Win32::Foundation::MAX_PATH;
@@ -247,7 +246,7 @@ impl EventTraceLogfile {
             u32::from(ProcessTraceMode::RealTime) | u32::from(ProcessTraceMode::EventRecord);
 
         log_file.0.Anonymous2.EventRecordCallback = Some(callback);
-        log_file.0.Context = unsafe { std::mem::transmute(trace_data as *const _) };
+        log_file.0.Context = trace_data as *const _ as *mut _;
 
         log_file
     }

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -288,6 +288,12 @@ impl std::ops::DerefMut for EventTraceLogfile {
     }
 }
 
+impl std::ops::Drop for EventTraceLogfile {
+    fn drop(&mut self) {
+        // FIXME: How do we drop the callback context?
+    }
+}
+
 /// Newtype wrapper over an [ENABLE_TRACE_PARAMETERS]
 ///
 /// [ENABLE_TRACE_PARAMETERS]: https://microsoft.github.io/windows-docs-rs/doc/bindings/Windows/Win32/Etw/struct.ENABLE_TRACE_PARAMETERS.html

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -183,7 +183,7 @@ impl TraceInfo {
         &mut self,
         trace_name: &str,
         trace_properties: &TraceProperties,
-        providers: &RwLock<Vec<Provider>>,
+        providers: &Vec<Provider>,
     ) where
         T: TraceTrait,
     {

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -82,7 +82,7 @@ impl NativeEtw {
         &mut self,
         name: &str,
         properties: &TraceProperties,
-        providers: &RwLock<Vec<Provider>>,
+        providers: &Vec<Provider>,
     ) where
         T: TraceTrait,
     {

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -243,17 +243,19 @@ impl NativeEtw {
 }
 
 /// Queries the system for system-wide ETW information (that does not require an active session).
-pub(crate) fn query_info(class: TraceInformation, buf: &mut [u8]) -> EvntraceNativeResult<()> {
+pub(crate) fn query_info(class: TraceInformation, buf: &mut [u8]) -> EvntraceNativeResult<usize> {
+    let mut ret_len = 0u32;
+
     match unsafe {
         Etw::TraceQueryInformation(
             0,
             TRACE_QUERY_INFO_CLASS(class as i32),
             buf.as_mut_ptr() as *mut std::ffi::c_void,
             buf.len() as u32,
-            std::ptr::null_mut(),
+            &mut ret_len,
         )
     } {
-        0 => Ok(()),
+        0 => Ok(ret_len as usize),
         e => Err(EvntraceNativeError::IoError(
             std::io::Error::from_raw_os_error(e as i32),
         )),

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -6,19 +6,22 @@
 //! This module shouldn't be accessed directly. Modules from the crate level provide a safe API to interact
 //! with the crate
 use windows::core::{GUID, PCSTR};
-use windows::Win32::Foundation::FILETIME;
-use windows::Win32::System::Diagnostics::Etw;
-use windows::Win32::System::SystemInformation::GetSystemTimeAsFileTime;
 use windows::Win32::Foundation::ERROR_ALREADY_EXISTS;
 use windows::Win32::Foundation::ERROR_CTX_CLOSE_PENDING;
 use windows::Win32::Foundation::ERROR_WMI_INSTANCE_NOT_FOUND;
+use windows::Win32::Foundation::FILETIME;
+use windows::Win32::System::Diagnostics::Etw::{
+    self, EVENT_CONTROL_CODE_ENABLE_PROVIDER, TRACE_QUERY_INFO_CLASS,
+};
+use windows::Win32::System::SystemInformation::GetSystemTimeAsFileTime;
 
+use std::panic::AssertUnwindSafe;
+use std::sync::RwLock;
 
 use super::etw_types::*;
 use crate::provider::Provider;
 use crate::trace::{TraceData, TraceProperties, TraceTrait};
 use crate::traits::*;
-use std::sync::RwLock;
 
 /// Evntrace native module errors
 #[derive(Debug)]
@@ -42,11 +45,19 @@ impl From<std::io::Error> for EvntraceNativeError {
 pub(crate) type EvntraceNativeResult<T> = Result<T, EvntraceNativeError>;
 
 unsafe extern "system" fn trace_callback_thunk(event_record: PEventRecord) {
-    let ctx: &mut TraceData = TraceData::unsafe_get_callback_ctx((*event_record).UserContext);
-    ctx.on_event(*event_record);
+    match std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let ctx: &TraceData = TraceData::unsafe_get_callback_ctx((*event_record).UserContext);
+        ctx.on_event(*event_record);
+    })) {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("UNIMPLEMENTED PANIC: {e:?}");
+            std::process::exit(1);
+        }
+    }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct NativeEtw {
     info: TraceInfo,
     session_handle: TraceHandle,
@@ -78,13 +89,6 @@ impl NativeEtw {
         self.info.fill::<T>(name, properties, providers);
     }
 
-    pub(crate) fn start(&mut self) -> EvntraceNativeResult<()> {
-        if self.session_handle == INVALID_TRACE_HANDLE {
-            return Err(EvntraceNativeError::InvalidHandle);
-        }
-        self.process()
-    }
-
     pub(crate) fn open(
         &mut self,
         trace_data: &TraceData,
@@ -92,31 +96,34 @@ impl NativeEtw {
         self.open_trace(trace_data)
     }
 
-    pub(crate) fn stop(&mut self, trace_data: &TraceData) -> EvntraceNativeResult<()> {
-        self.stop_trace(trace_data)?;
-        self.close_trace()?;
-        Ok(())
+    pub(crate) fn close(&mut self) -> EvntraceNativeResult<()> {
+        self.close_trace()
     }
 
-    pub(crate) fn process(&mut self) -> EvntraceNativeResult<()> {
+    pub(crate) fn start(&mut self, trace_data: &TraceData) -> EvntraceNativeResult<()> {
+        self.start_trace(trace_data)
+    }
+
+    pub(crate) fn stop(&self, trace_data: &TraceData) -> EvntraceNativeResult<()> {
+        self.stop_trace(trace_data)
+    }
+
+    pub(crate) fn process(&self) -> EvntraceNativeResult<()> {
         if self.session_handle == INVALID_TRACE_HANDLE {
             return Err(EvntraceNativeError::InvalidHandle);
         }
 
-        let clone_handle = self.session_handle;
-        std::thread::spawn(move || {
-            let mut now = FILETIME::default();
-            unsafe {
-                GetSystemTimeAsFileTime(&mut now);
+        let mut now = FILETIME::default();
+        unsafe {
+            GetSystemTimeAsFileTime(&mut now);
 
-                Etw::ProcessTrace(&[clone_handle], &now, std::ptr::null_mut());
-                // if Etw::ProcessTrace(&[clone_handlee], &mut now, std::ptr::null_mut()) != 0 {
-                //     return Err(EvntraceNativeError::IoError(std::io::Error::last_os_error()));
-                // }
+            match Etw::ProcessTrace(&[self.session_handle], &mut now, std::ptr::null_mut()) {
+                0 => Ok(()),
+                e => Err(EvntraceNativeError::IoError(
+                    std::io::Error::from_raw_os_error(e as i32),
+                )),
             }
-        });
-
-        Ok(())
+        }
     }
 
     pub(crate) fn register_trace(&mut self, trace_data: &TraceData) -> EvntraceNativeResult<()> {
@@ -143,7 +150,9 @@ impl NativeEtw {
             if status == ERROR_ALREADY_EXISTS.0 {
                 return Err(EvntraceNativeError::AlreadyExist);
             } else if status != 0 {
-                return Err(EvntraceNativeError::IoError(std::io::Error::last_os_error()));
+                return Err(EvntraceNativeError::IoError(
+                    std::io::Error::from_raw_os_error(status as i32),
+                ));
             }
         }
         Ok(())
@@ -162,7 +171,8 @@ impl NativeEtw {
         Ok(log_file)
     }
 
-    fn stop_trace(&mut self, trace_data: &TraceData) -> EvntraceNativeResult<()> {
+    fn stop_trace(&self, trace_data: &TraceData) -> EvntraceNativeResult<()> {
+        // FIXME: The session handle is no longer valid after this call.
         self.control_trace(
             trace_data,
             windows::Win32::System::Diagnostics::Etw::EVENT_TRACE_CONTROL_STOP,
@@ -189,7 +199,7 @@ impl NativeEtw {
     }
 
     fn control_trace(
-        &mut self,
+        &self,
         trace_data: &TraceData,
         control_code: EvenTraceControl,
     ) -> EvntraceNativeResult<()> {
@@ -197,7 +207,7 @@ impl NativeEtw {
             let status = Etw::ControlTraceA(
                 0,
                 PCSTR::from_raw(trace_data.name.as_ptr()),
-                &mut *self.info.properties,
+                &*self.info.properties as *const _ as *mut _,
                 control_code,
             );
 
@@ -211,7 +221,7 @@ impl NativeEtw {
         Ok(())
     }
 
-    pub(crate) fn enable_trace(
+    pub(crate) fn enable_provider(
         &self,
         guid: GUID,
         any: u64,
@@ -219,21 +229,40 @@ impl NativeEtw {
         level: u8,
         parameters: EnableTraceParameters,
     ) -> EvntraceNativeResult<()> {
-        unsafe {
-            if Etw::EnableTraceEx2(
+        match unsafe {
+            Etw::EnableTraceEx2(
                 self.registration_handle,
                 &guid,
-                1, // Fixme: EVENT_CONTROL_CODE_ENABLE_PROVIDER
+                EVENT_CONTROL_CODE_ENABLE_PROVIDER.0,
                 level,
                 any,
                 all,
                 0,
                 &*parameters,
-            ) != 0
-            {
-                return Err(EvntraceNativeError::IoError(std::io::Error::last_os_error()));
-            }
+            )
+        } {
+            0 => Ok(()),
+            e => Err(EvntraceNativeError::IoError(
+                std::io::Error::from_raw_os_error(e as i32),
+            )),
         }
-        Ok(())
+    }
+}
+
+/// Queries the system for system-wide ETW information (that does not require an active session).
+pub(crate) fn query_info(class: TraceInformation, buf: &mut [u8]) -> EvntraceNativeResult<()> {
+    match unsafe {
+        Etw::TraceQueryInformation(
+            0,
+            TRACE_QUERY_INFO_CLASS(class as i32),
+            buf.as_mut_ptr() as *mut std::ffi::c_void,
+            buf.len() as u32,
+            std::ptr::null_mut(),
+        )
+    } {
+        0 => Ok(()),
+        e => Err(EvntraceNativeError::IoError(
+            std::io::Error::from_raw_os_error(e as i32),
+        )),
     }
 }

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -16,7 +16,6 @@ use windows::Win32::System::Diagnostics::Etw::{
 use windows::Win32::System::SystemInformation::GetSystemTimeAsFileTime;
 
 use std::panic::AssertUnwindSafe;
-use std::sync::RwLock;
 
 use super::etw_types::*;
 use crate::provider::Provider;
@@ -223,6 +222,7 @@ impl NativeEtw {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn enable_provider(
         &self,
         guid: GUID,

--- a/src/native/pla.rs
+++ b/src/native/pla.rs
@@ -75,7 +75,7 @@ pub struct Variant {
 
 impl Variant {
     pub fn new(vt: u16, val: u32) -> Self {
-        Variant{
+        Variant {
             vt,
             val,
             ..Default::default()
@@ -151,7 +151,7 @@ pub(crate) unsafe fn get_provider_guid(name: &str) -> ProvidersComResult<GUID> {
 }
 
 mod pla_interfaces {
-    use super::{GUID, Variant, BSTR};
+    use super::{Variant, BSTR, GUID};
     use com::sys::IID;
     use com::{interfaces, interfaces::iunknown::IUnknown, sys::HRESULT};
 

--- a/src/native/sddl.rs
+++ b/src/native/sddl.rs
@@ -1,10 +1,10 @@
 use crate::traits::*;
-use std::str::Utf8Error;
 use core::ffi::c_void;
+use std::str::Utf8Error;
 use windows::core::PSTR;
 use windows::Win32::Foundation::PSID;
-use windows::Win32::System::Memory::LocalFree;
 use windows::Win32::Security::Authorization::ConvertSidToStringSidA;
+use windows::Win32::System::Memory::LocalFree;
 
 /// SDDL native error
 #[derive(Debug)]

--- a/src/native/tdh.rs
+++ b/src/native/tdh.rs
@@ -7,8 +7,8 @@
 //! with the crate
 use super::etw_types::*;
 use crate::traits::*;
-use windows::Win32::System::Diagnostics::Etw;
 use windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
+use windows::Win32::System::Diagnostics::Etw;
 
 /// Tdh native module errors
 #[derive(Debug)]
@@ -30,12 +30,8 @@ pub(crate) type TdhNativeResult<T> = Result<T, TdhNativeError>;
 pub(crate) fn schema_from_tdh(event: EventRecord) -> TdhNativeResult<TraceEventInfoRaw> {
     let mut buffer_size = 0;
     unsafe {
-        if Etw::TdhGetEventInformation(
-            &event,
-            &[],
-            std::ptr::null_mut(),
-            &mut buffer_size,
-        ) != ERROR_INSUFFICIENT_BUFFER.0
+        if Etw::TdhGetEventInformation(&event, &[], std::ptr::null_mut(), &mut buffer_size)
+            != ERROR_INSUFFICIENT_BUFFER.0
         {
             return Err(TdhNativeError::IoError(std::io::Error::last_os_error()));
         }
@@ -59,19 +55,14 @@ pub(crate) fn property_size(event: EventRecord, name: &str) -> TdhNativeResult<u
     let mut property_size = 0;
 
     let name = name.into_utf16();
-    let desc = Etw::PROPERTY_DATA_DESCRIPTOR{
+    let desc = Etw::PROPERTY_DATA_DESCRIPTOR {
         ArrayIndex: u32::MAX,
         PropertyName: name.as_ptr() as u64,
         ..Default::default()
     };
 
     unsafe {
-        let status = Etw::TdhGetPropertySize(
-            &event,
-            &[],
-            &[desc],
-            &mut property_size,
-        );
+        let status = Etw::TdhGetPropertySize(&event, &[], &[desc], &mut property_size);
         if status != 0 {
             return Err(TdhNativeError::IoError(std::io::Error::from_raw_os_error(
                 status as i32,

--- a/src/native/tdh_types.rs
+++ b/src/native/tdh_types.rs
@@ -15,7 +15,6 @@ use num_traits::FromPrimitive;
 
 use windows::Win32::System::Diagnostics::Etw;
 
-
 /// Attributes of a property
 #[derive(Debug, Clone, Default)]
 pub struct Property {

--- a/src/native/version_helper.rs
+++ b/src/native/version_helper.rs
@@ -5,8 +5,10 @@
 //!
 //! At the moment the only option available is to check if the actual System Version is greater than
 //! Win8, is the only check we need for the crate to work as expected
-use windows::Win32::System::SystemInformation::{OSVERSIONINFOEXA, VER_MAJORVERSION, VER_MINORVERSION, VER_SERVICEPACKMAJOR};
-use windows::Win32::System::SystemInformation::{VerifyVersionInfoA, VerSetConditionMask};
+use windows::Win32::System::SystemInformation::{VerSetConditionMask, VerifyVersionInfoA};
+use windows::Win32::System::SystemInformation::{
+    OSVERSIONINFOEXA, VER_MAJORVERSION, VER_MINORVERSION, VER_SERVICEPACKMAJOR,
+};
 
 use crate::traits::*;
 
@@ -32,7 +34,7 @@ type OsVersionInfo = OSVERSIONINFOEXA;
 const VER_GREATER_OR_EQUAL: u8 = windows::Win32::System::SystemServices::VER_GREATER_EQUAL as u8;
 
 fn verify_system_version(major: u8, minor: u8, sp_major: u16) -> VersionHelperResult<bool> {
-    let mut os_version = OsVersionInfo{
+    let mut os_version = OsVersionInfo {
         dwOSVersionInfoSize: std::mem::size_of::<OsVersionInfo>() as u32,
         dwMajorVersion: major as u32,
         dwMinorVersion: minor as u32,
@@ -42,27 +44,16 @@ fn verify_system_version(major: u8, minor: u8, sp_major: u16) -> VersionHelperRe
 
     let mut condition_mask = 0;
     unsafe {
-        condition_mask = VerSetConditionMask(
-            condition_mask,
-            VER_MAJORVERSION,
-            VER_GREATER_OR_EQUAL,
-        );
-        condition_mask = VerSetConditionMask(
-            condition_mask,
-            VER_MINORVERSION,
-            VER_GREATER_OR_EQUAL,
-        );
-        condition_mask = VerSetConditionMask(
-            condition_mask,
-            VER_SERVICEPACKMAJOR,
-            VER_GREATER_OR_EQUAL,
-        );
+        condition_mask =
+            VerSetConditionMask(condition_mask, VER_MAJORVERSION, VER_GREATER_OR_EQUAL);
+        condition_mask =
+            VerSetConditionMask(condition_mask, VER_MINORVERSION, VER_GREATER_OR_EQUAL);
+        condition_mask =
+            VerSetConditionMask(condition_mask, VER_SERVICEPACKMAJOR, VER_GREATER_OR_EQUAL);
 
         Ok(VerifyVersionInfoA(
             &mut os_version,
-            VER_MAJORVERSION
-                | VER_MINORVERSION
-                | VER_SERVICEPACKMAJOR,
+            VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR,
             condition_mask,
         ) != false)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -106,7 +106,7 @@ impl<'a> Parser<'a> {
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
     /// # use ferrisetw::parser::Parser;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let parser = Parser::create(&schema);
     /// };
@@ -247,7 +247,7 @@ impl_try_parse_primitive!(isize);
 /// # use ferrisetw::native::etw_types::EventRecord;
 /// # use ferrisetw::schema::SchemaLocator;
 /// # use ferrisetw::parser::{Parser, TryParse};
-/// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+/// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
 ///     let schema = schema_locator.event_schema(record).unwrap();
 ///     let mut parser = Parser::create(&schema);
 ///     let image_name: String = parser.try_parse("ImageName").unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -135,17 +135,16 @@ impl<'a> Parser<'a> {
             .intersects(PropertyFlags::PROPERTY_PARAM_LENGTH) == false
             && (property.len() > 0)
         {
-            let size = match property.in_type() {
-                TdhInType::InTypePointer => property.len() as usize,
-                _ => {
-                    // There is an exception regarding pointer size though
-                    // When reading captures, we should take care of the pointer size at the _source_, rather than the current architecture's pointer size.
-                    // Note that a 32-bit program on a 64-bit OS would still send 32-bit pointers
-                    if (self.schema.event_flags() & EVENT_HEADER_FLAG_32_BIT_HEADER) != 0 {
-                        4
-                    } else {
-                        8
-                    }
+            let size = if property.in_type() != TdhInType::InTypePointer {
+                property.len()
+            } else {
+                // There is an exception regarding pointer size though
+                // When reading captures, we should take care of the pointer size at the _source_, rather than the current architecture's pointer size.
+                // Note that a 32-bit program on a 64-bit OS would still send 32-bit pointers
+                if (self.schema.event_flags() & EVENT_HEADER_FLAG_32_BIT_HEADER) != 0 {
+                    4
+                } else {
+                    8
                 }
             };
             return Ok(size);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -158,7 +158,7 @@ impl<'a> Parser<'a> {
             return Ok(property.len());
         }
 
-        Ok(tdh::property_size(self.schema.record(), &property.name)? as usize)
+        Ok(tdh::property_size(&self.schema.record(), &property.name)? as usize)
     }
 
     fn find_property(&mut self, name: &str) -> ParserResult<Rc<PropertyInfo>> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -132,7 +132,8 @@ impl<'a> Parser<'a> {
 
         if property
             .flags
-            .intersects(PropertyFlags::PROPERTY_PARAM_LENGTH) == false
+            .intersects(PropertyFlags::PROPERTY_PARAM_LENGTH)
+            == false
             && (property.len() > 0)
         {
             let size = if property.in_type() != TdhInType::InTypePointer {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -536,7 +536,7 @@ impl Provider {
     /// # use ferrisetw::provider::Provider;
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// Provider::new().add_callback(|record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// Provider::new().add_callback(|record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     // Handle Event
     /// });
     /// ```

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -364,7 +364,8 @@ pub mod kernel_providers {
         KernelProvider::new(kernel_guids::ALPC_GUID, kernel_flags::EVENT_TRACE_FLAG_ALPC);
 }
 
-type EtwCallback = Box<dyn FnMut(EventRecord, &mut schema::SchemaLocator) + Send + Sync + 'static>;
+type EtwCallback =
+    Box<dyn FnMut(&mut EventRecord, &mut schema::SchemaLocator) + Send + Sync + 'static>;
 
 /// Main Provider structure
 pub struct Provider {
@@ -543,7 +544,7 @@ impl Provider {
     /// [SchemaLocator]: crate::schema::SchemaLocator
     pub fn add_callback<T>(self, callback: T) -> Self
     where
-        T: FnMut(EventRecord, &mut schema::SchemaLocator) + Send + Sync + 'static,
+        T: FnMut(&mut EventRecord, &mut schema::SchemaLocator) + Send + Sync + 'static,
     {
         if let Ok(mut callbacks) = self.callbacks.write() {
             callbacks.push(Box::new(callback));
@@ -584,7 +585,7 @@ impl Provider {
         Ok(self)
     }
 
-    pub(crate) fn on_event(&self, record: EventRecord, locator: &mut schema::SchemaLocator) {
+    pub(crate) fn on_event(&self, record: &mut EventRecord, locator: &mut schema::SchemaLocator) {
         // Has to be mutable because the SchemaLocator will be mutated when locating the schema
         // within the cb creating a clone of the whole SchemaLocator HashMap doesn't
         // sound like a plan still needs to think more about this thou...

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -53,51 +53,143 @@ pub mod kernel_providers {
     pub mod kernel_guids {
         use super::GUID;
         pub const ALPC_GUID: GUID = GUID::from_values(
-            0x45d8cccd, 0x539f, 0x4b72, [0xa8, 0xb7, 0x5c, 0x68, 0x31, 0x42, 0x60, 0x9a]);
+            0x45d8cccd,
+            0x539f,
+            0x4b72,
+            [0xa8, 0xb7, 0x5c, 0x68, 0x31, 0x42, 0x60, 0x9a],
+        );
         pub const POWER_GUID: GUID = GUID::from_values(
-            0xe43445e0, 0x0903, 0x48c3, [0xb8, 0x78, 0xff, 0x0f, 0xcc, 0xeb, 0xdd, 0x04]);
+            0xe43445e0,
+            0x0903,
+            0x48c3,
+            [0xb8, 0x78, 0xff, 0x0f, 0xcc, 0xeb, 0xdd, 0x04],
+        );
         pub const DEBUG_GUID: GUID = GUID::from_values(
-            0x13976d09, 0xa327, 0x438c, [0x95, 0x0b, 0x7f, 0x03, 0x19, 0x28, 0x15, 0xc7]);
+            0x13976d09,
+            0xa327,
+            0x438c,
+            [0x95, 0x0b, 0x7f, 0x03, 0x19, 0x28, 0x15, 0xc7],
+        );
         pub const TCP_IP_GUID: GUID = GUID::from_values(
-            0x9a280ac0, 0xc8e0, 0x11d1, [0x84, 0xe2, 0x00, 0xc0, 0x4f, 0xb9, 0x98, 0xa2]);
+            0x9a280ac0,
+            0xc8e0,
+            0x11d1,
+            [0x84, 0xe2, 0x00, 0xc0, 0x4f, 0xb9, 0x98, 0xa2],
+        );
         pub const UDP_IP_GUID: GUID = GUID::from_values(
-            0xbf3a50c5, 0xa9c9, 0x4988, [0xa0, 0x05, 0x2d, 0xf0, 0xb7, 0xc8, 0x0f, 0x80]);
+            0xbf3a50c5,
+            0xa9c9,
+            0x4988,
+            [0xa0, 0x05, 0x2d, 0xf0, 0xb7, 0xc8, 0x0f, 0x80],
+        );
         pub const THREAD_GUID: GUID = GUID::from_values(
-            0x3d6fa8d1, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+            0x3d6fa8d1,
+            0xfe05,
+            0x11d0,
+            [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+        );
         pub const DISK_IO_GUID: GUID = GUID::from_values(
-            0x3d6fa8d4, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+            0x3d6fa8d4,
+            0xfe05,
+            0x11d0,
+            [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+        );
         pub const FILE_IO_GUID: GUID = GUID::from_values(
-            0x90cbdc39, 0x4a3e, 0x11d1, [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3]);
+            0x90cbdc39,
+            0x4a3e,
+            0x11d1,
+            [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3],
+        );
         pub const PROCESS_GUID: GUID = GUID::from_values(
-            0x3d6fa8d0, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+            0x3d6fa8d0,
+            0xfe05,
+            0x11d0,
+            [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+        );
         pub const REGISTRY_GUID: GUID = GUID::from_values(
-            0xAE53722E, 0xC863, 0x11d2, [0x86, 0x59, 0x00, 0xC0, 0x4F, 0xA3, 0x21, 0xA1]);
+            0xAE53722E,
+            0xC863,
+            0x11d2,
+            [0x86, 0x59, 0x00, 0xC0, 0x4F, 0xA3, 0x21, 0xA1],
+        );
         pub const SPLIT_IO_GUID: GUID = GUID::from_values(
-            0xd837ca92, 0x12b9, 0x44a5, [0xad, 0x6a, 0x3a, 0x65, 0xb3, 0x57, 0x8a, 0xa8]);
+            0xd837ca92,
+            0x12b9,
+            0x44a5,
+            [0xad, 0x6a, 0x3a, 0x65, 0xb3, 0x57, 0x8a, 0xa8],
+        );
         pub const OB_TRACE_GUID: GUID = GUID::from_values(
-            0x89497f50, 0xeffe, 0x4440, [0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7]);
+            0x89497f50,
+            0xeffe,
+            0x4440,
+            [0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7],
+        );
         pub const UMS_EVENT_GUID: GUID = GUID::from_values(
-            0x9aec974b, 0x5b8e, 0x4118, [0x9b, 0x92, 0x31, 0x86, 0xd8, 0x00, 0x2c, 0xe5]);
+            0x9aec974b,
+            0x5b8e,
+            0x4118,
+            [0x9b, 0x92, 0x31, 0x86, 0xd8, 0x00, 0x2c, 0xe5],
+        );
         pub const PERF_INFO_GUID: GUID = GUID::from_values(
-            0xce1dbfb4, 0x137e, 0x4da6, [0x87, 0xb0, 0x3f, 0x59, 0xaa, 0x10, 0x2c, 0xbc]);
+            0xce1dbfb4,
+            0x137e,
+            0x4da6,
+            [0x87, 0xb0, 0x3f, 0x59, 0xaa, 0x10, 0x2c, 0xbc],
+        );
         pub const PAGE_FAULT_GUID: GUID = GUID::from_values(
-            0x3d6fa8d3, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+            0x3d6fa8d3,
+            0xfe05,
+            0x11d0,
+            [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+        );
         pub const IMAGE_LOAD_GUID: GUID = GUID::from_values(
-            0x2cb15d1d, 0x5fc1, 0x11d2, [0xab, 0xe1, 0x00, 0xa0, 0xc9, 0x11, 0xf5, 0x18]);
+            0x2cb15d1d,
+            0x5fc1,
+            0x11d2,
+            [0xab, 0xe1, 0x00, 0xa0, 0xc9, 0x11, 0xf5, 0x18],
+        );
         pub const POOL_TRACE_GUID: GUID = GUID::from_values(
-            0x0268a8b6, 0x74fd, 0x4302, [0x9d, 0xd0, 0x6e, 0x8f, 0x17, 0x95, 0xc0, 0xcf]);
+            0x0268a8b6,
+            0x74fd,
+            0x4302,
+            [0x9d, 0xd0, 0x6e, 0x8f, 0x17, 0x95, 0xc0, 0xcf],
+        );
         pub const LOST_EVENT_GUID: GUID = GUID::from_values(
-            0x6a399ae0, 0x4bc6, 0x4de9, [0x87, 0x0b, 0x36, 0x57, 0xf8, 0x94, 0x7e, 0x7e]);
+            0x6a399ae0,
+            0x4bc6,
+            0x4de9,
+            [0x87, 0x0b, 0x36, 0x57, 0xf8, 0x94, 0x7e, 0x7e],
+        );
         pub const STACK_WALK_GUID: GUID = GUID::from_values(
-            0xdef2fe46, 0x7bd6, 0x4b80, [0xbd, 0x94, 0xf5, 0x7f, 0xe2, 0x0d, 0x0c, 0xe3]);
+            0xdef2fe46,
+            0x7bd6,
+            0x4b80,
+            [0xbd, 0x94, 0xf5, 0x7f, 0xe2, 0x0d, 0x0c, 0xe3],
+        );
         pub const EVENT_TRACE_GUID: GUID = GUID::from_values(
-            0x68fdd900, 0x4a3e, 0x11d1, [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3]);
+            0x68fdd900,
+            0x4a3e,
+            0x11d1,
+            [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3],
+        );
         pub const MMCSS_TRACE_GUID: GUID = GUID::from_values(
-            0xf8f10121, 0xb617, 0x4a56, [0x86, 0x8b, 0x9d, 0xf1, 0xb2, 0x7f, 0xe3, 0x2c]);
+            0xf8f10121,
+            0xb617,
+            0x4a56,
+            [0x86, 0x8b, 0x9d, 0xf1, 0xb2, 0x7f, 0xe3, 0x2c],
+        );
         pub const SYSTEM_TRACE_GUID: GUID = GUID::from_values(
-            0x9e814aad, 0x3204, 0x11d2, [0x9a, 0x82, 0x00, 0x60, 0x08, 0xa8, 0x69, 0x39]);
+            0x9e814aad,
+            0x3204,
+            0x11d2,
+            [0x9a, 0x82, 0x00, 0x60, 0x08, 0xa8, 0x69, 0x39],
+        );
         pub const EVENT_TRACE_CONFIG_GUID: GUID = GUID::from_values(
-            0x01853a65, 0x418f, 0x4f36, [0xae, 0xfc, 0xdc, 0x0f, 0x1d, 0x2f, 0xd2, 0x35]);
+            0x01853a65,
+            0x418f,
+            0x4f36,
+            [0xae, 0xfc, 0xdc, 0x0f, 0x1d, 0x2f, 0xd2, 0x35],
+        );
     }
 
     /// List of Kernel Providers flags
@@ -143,123 +235,130 @@ pub mod kernel_providers {
     impl KernelProvider {
         /// Use the `new` function to create a Kernel Provider which can be then tied into a Provider
         pub const fn new(guid: GUID, flags: u32) -> KernelProvider {
-            KernelProvider {
-                guid,
-                flags,
-            }
+            KernelProvider { guid, flags }
         }
     }
 
     /// Represents the VirtualAlloc Kernel Provider
     pub static VIRTUAL_ALLOC_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PAGE_FAULT_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_VIRTUAL_ALLOC
+        kernel_flags::EVENT_TRACE_FLAG_VIRTUAL_ALLOC,
     );
     /// Represents the VA Map Kernel Provider
-    pub static VAMAP_PROVIDER: KernelProvider =
-        KernelProvider::new(kernel_guids::FILE_IO_GUID, kernel_flags::EVENT_TRACE_FLAG_VAMAP);
+    pub static VAMAP_PROVIDER: KernelProvider = KernelProvider::new(
+        kernel_guids::FILE_IO_GUID,
+        kernel_flags::EVENT_TRACE_FLAG_VAMAP,
+    );
     /// Represents the Thread Kernel Provider
-    pub static THREAD_PROVIDER: KernelProvider =
-        KernelProvider::new(kernel_guids::THREAD_GUID, kernel_flags::EVENT_TRACE_FLAG_THREAD);
+    pub static THREAD_PROVIDER: KernelProvider = KernelProvider::new(
+        kernel_guids::THREAD_GUID,
+        kernel_flags::EVENT_TRACE_FLAG_THREAD,
+    );
     /// Represents the Split IO Kernel Provider
     pub static SPLIT_IO_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::SPLIT_IO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_SPLIT_IO
+        kernel_flags::EVENT_TRACE_FLAG_SPLIT_IO,
     );
     /// Represents the SystemCall Kernel Provider
     pub static SYSTEM_CALL_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PERF_INFO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_SYSTEMCALL
+        kernel_flags::EVENT_TRACE_FLAG_SYSTEMCALL,
     );
     /// Represents the Registry Kernel Provider
     pub static REGISTRY_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::REGISTRY_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_REGISTRY
+        kernel_flags::EVENT_TRACE_FLAG_REGISTRY,
     );
     /// Represents the Profile Kernel Provider
     pub static PROFILE_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PERF_INFO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_PROFILE
+        kernel_flags::EVENT_TRACE_FLAG_PROFILE,
     );
     /// Represents the Process Counter Kernel Provider
     pub static PROCESS_COUNTER_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PROCESS_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_PROCESS_COUNTERS
+        kernel_flags::EVENT_TRACE_FLAG_PROCESS_COUNTERS,
     );
     /// Represents the Process Kernel Provider
     pub static PROCESS_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PROCESS_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_PROCESS
+        kernel_flags::EVENT_TRACE_FLAG_PROCESS,
     );
     /// Represents the TCP-IP Kernel Provider
     pub static TCP_IP_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::TCP_IP_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_NETWORK_TCPIP
+        kernel_flags::EVENT_TRACE_FLAG_NETWORK_TCPIP,
     );
     /// Represents the Memory Page Fault Kernel Provider
     pub static MEMORY_PAGE_FAULT_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PAGE_FAULT_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_MEMORY_PAGE_FAULTS
+        kernel_flags::EVENT_TRACE_FLAG_MEMORY_PAGE_FAULTS,
     );
     /// Represents the Memory Hard Fault Kernel Provider
     pub static MEMORY_HARD_FAULT_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PAGE_FAULT_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_MEMORY_HARD_FAULTS
+        kernel_flags::EVENT_TRACE_FLAG_MEMORY_HARD_FAULTS,
     );
     /// Represents the Interrupt Kernel Provider
     pub static INTERRUPT_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::PERF_INFO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_INTERRUPT
+        kernel_flags::EVENT_TRACE_FLAG_INTERRUPT,
     );
     /// Represents the Driver Kernel Provider
     pub static DRIVER_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::DISK_IO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_DISK_IO
+        kernel_flags::EVENT_TRACE_FLAG_DISK_IO,
     );
     /// Represents the DPC Kernel Provider
-    pub static DPC_PROVIDER: KernelProvider =
-        KernelProvider::new(kernel_guids::PERF_INFO_GUID, kernel_flags::EVENT_TRACE_FLAG_DPC);
+    pub static DPC_PROVIDER: KernelProvider = KernelProvider::new(
+        kernel_guids::PERF_INFO_GUID,
+        kernel_flags::EVENT_TRACE_FLAG_DPC,
+    );
     /// Represents the Image Load Kernel Provider
     pub static IMAGE_LOAD_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::IMAGE_LOAD_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_IMAGE_LOAD
+        kernel_flags::EVENT_TRACE_FLAG_IMAGE_LOAD,
     );
     /// Represents the Thread Dispatcher Kernel Provider
     pub static THREAD_DISPATCHER_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::THREAD_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_DISPATCHER
+        kernel_flags::EVENT_TRACE_FLAG_DISPATCHER,
     );
     /// Represents the File Init IO Kernel Provider
     pub static FILE_INIT_IO_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::FILE_IO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_FILE_IO_INIT
+        kernel_flags::EVENT_TRACE_FLAG_FILE_IO_INIT,
     );
     /// Represents the File IO Kernel Provider
     pub static FILE_IO_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::FILE_IO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_FILE_IO
+        kernel_flags::EVENT_TRACE_FLAG_FILE_IO,
     );
     /// Represents the Disk IO Init Kernel Provider
     pub static DISK_IO_INIT_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::DISK_IO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_DISK_IO_INIT
+        kernel_flags::EVENT_TRACE_FLAG_DISK_IO_INIT,
     );
     /// Represents the Disk IO Kernel Provider
     pub static DISK_IO_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::DISK_IO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_DISK_IO
+        kernel_flags::EVENT_TRACE_FLAG_DISK_IO,
     );
     /// Represents the Disk File IO Kernel Provider
     pub static DISK_FILE_IO_PROVIDER: KernelProvider = KernelProvider::new(
         kernel_guids::DISK_IO_GUID,
-        kernel_flags::EVENT_TRACE_FLAG_DISK_FILE_IO
+        kernel_flags::EVENT_TRACE_FLAG_DISK_FILE_IO,
     );
     /// Represents the Dbg Pring Kernel Provider
-    pub static DEBUG_PRINT_PROVIDER: KernelProvider =
-        KernelProvider::new(kernel_guids::DEBUG_GUID, kernel_flags::EVENT_TRACE_FLAG_DBGPRINT);
+    pub static DEBUG_PRINT_PROVIDER: KernelProvider = KernelProvider::new(
+        kernel_guids::DEBUG_GUID,
+        kernel_flags::EVENT_TRACE_FLAG_DBGPRINT,
+    );
     /// Represents the Context Swtich Kernel Provider
-    pub static CONTEXT_SWITCH_PROVIDER: KernelProvider =
-        KernelProvider::new(kernel_guids::THREAD_GUID, kernel_flags::EVENT_TRACE_FLAG_CSWITCH);
+    pub static CONTEXT_SWITCH_PROVIDER: KernelProvider = KernelProvider::new(
+        kernel_guids::THREAD_GUID,
+        kernel_flags::EVENT_TRACE_FLAG_CSWITCH,
+    );
     /// Represents the ALPC Kernel Provider
     pub static ALPC_PROVIDER: KernelProvider =
         KernelProvider::new(kernel_guids::ALPC_GUID, kernel_flags::EVENT_TRACE_FLAG_ALPC);
@@ -573,7 +672,8 @@ mod test {
 
     #[test]
     fn test_kernel_provider_struct() {
-        let kernel_provider = KernelProvider::new("D396B546-287D-4712-A7F5-8BE226A8C643".into(), 0x10000);
+        let kernel_provider =
+            KernelProvider::new("D396B546-287D-4712-A7F5-8BE226A8C643".into(), 0x10000);
 
         assert_eq!(0x10000, kernel_provider.flags);
         assert_eq!(
@@ -597,28 +697,97 @@ mod test {
 
     #[test]
     fn test_kernel_provider_guids_correct() {
-        assert_eq!(ALPC_GUID, GUID::from("45d8cccd-539f-4b72-a8b7-5c683142609a"));
-        assert_eq!(POWER_GUID, GUID::from("e43445e0-0903-48c3-b878-ff0fccebdd04"));
-        assert_eq!(DEBUG_GUID, GUID::from("13976d09-a327-438c-950b-7f03192815c7"));
-        assert_eq!(TCP_IP_GUID, GUID::from("9a280ac0-c8e0-11d1-84e2-00c04fb998a2"));
-        assert_eq!(UDP_IP_GUID, GUID::from("bf3a50c5-a9c9-4988-a005-2df0b7c80f80"));
-        assert_eq!(THREAD_GUID, GUID::from("3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(DISK_IO_GUID, GUID::from("3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(FILE_IO_GUID, GUID::from("90cbdc39-4a3e-11d1-84f4-0000f80464e3"));
-        assert_eq!(PROCESS_GUID, GUID::from("3d6fa8d0-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(REGISTRY_GUID, GUID::from("AE53722E-C863-11d2-8659-00C04FA321A1"));
-        assert_eq!(SPLIT_IO_GUID, GUID::from("d837ca92-12b9-44a5-ad6a-3a65b3578aa8"));
-        assert_eq!(OB_TRACE_GUID, GUID::from("89497f50-effe-4440-8cf2-ce6b1cdcaca7"));
-        assert_eq!(UMS_EVENT_GUID, GUID::from("9aec974b-5b8e-4118-9b92-3186d8002ce5"));
-        assert_eq!(PERF_INFO_GUID, GUID::from("ce1dbfb4-137e-4da6-87b0-3f59aa102cbc"));
-        assert_eq!(PAGE_FAULT_GUID, GUID::from("3d6fa8d3-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(IMAGE_LOAD_GUID, GUID::from("2cb15d1d-5fc1-11d2-abe1-00a0c911f518"));
-        assert_eq!(POOL_TRACE_GUID, GUID::from("0268a8b6-74fd-4302-9dd0-6e8f1795c0cf"));
-        assert_eq!(LOST_EVENT_GUID, GUID::from("6a399ae0-4bc6-4de9-870b-3657f8947e7e"));
-        assert_eq!(STACK_WALK_GUID, GUID::from("def2fe46-7bd6-4b80-bd94-f57fe20d0ce3"));
-        assert_eq!(EVENT_TRACE_GUID, GUID::from("68fdd900-4a3e-11d1-84f4-0000f80464e3"));
-        assert_eq!(MMCSS_TRACE_GUID, GUID::from("f8f10121-b617-4a56-868b-9df1b27fe32c"));
-        assert_eq!(SYSTEM_TRACE_GUID, GUID::from("9e814aad-3204-11d2-9a82-006008a86939"));
-        assert_eq!(EVENT_TRACE_CONFIG_GUID, GUID::from("01853a65-418f-4f36-aefc-dc0f1d2fd235"));
+        assert_eq!(
+            ALPC_GUID,
+            GUID::from("45d8cccd-539f-4b72-a8b7-5c683142609a")
+        );
+        assert_eq!(
+            POWER_GUID,
+            GUID::from("e43445e0-0903-48c3-b878-ff0fccebdd04")
+        );
+        assert_eq!(
+            DEBUG_GUID,
+            GUID::from("13976d09-a327-438c-950b-7f03192815c7")
+        );
+        assert_eq!(
+            TCP_IP_GUID,
+            GUID::from("9a280ac0-c8e0-11d1-84e2-00c04fb998a2")
+        );
+        assert_eq!(
+            UDP_IP_GUID,
+            GUID::from("bf3a50c5-a9c9-4988-a005-2df0b7c80f80")
+        );
+        assert_eq!(
+            THREAD_GUID,
+            GUID::from("3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            DISK_IO_GUID,
+            GUID::from("3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            FILE_IO_GUID,
+            GUID::from("90cbdc39-4a3e-11d1-84f4-0000f80464e3")
+        );
+        assert_eq!(
+            PROCESS_GUID,
+            GUID::from("3d6fa8d0-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            REGISTRY_GUID,
+            GUID::from("AE53722E-C863-11d2-8659-00C04FA321A1")
+        );
+        assert_eq!(
+            SPLIT_IO_GUID,
+            GUID::from("d837ca92-12b9-44a5-ad6a-3a65b3578aa8")
+        );
+        assert_eq!(
+            OB_TRACE_GUID,
+            GUID::from("89497f50-effe-4440-8cf2-ce6b1cdcaca7")
+        );
+        assert_eq!(
+            UMS_EVENT_GUID,
+            GUID::from("9aec974b-5b8e-4118-9b92-3186d8002ce5")
+        );
+        assert_eq!(
+            PERF_INFO_GUID,
+            GUID::from("ce1dbfb4-137e-4da6-87b0-3f59aa102cbc")
+        );
+        assert_eq!(
+            PAGE_FAULT_GUID,
+            GUID::from("3d6fa8d3-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            IMAGE_LOAD_GUID,
+            GUID::from("2cb15d1d-5fc1-11d2-abe1-00a0c911f518")
+        );
+        assert_eq!(
+            POOL_TRACE_GUID,
+            GUID::from("0268a8b6-74fd-4302-9dd0-6e8f1795c0cf")
+        );
+        assert_eq!(
+            LOST_EVENT_GUID,
+            GUID::from("6a399ae0-4bc6-4de9-870b-3657f8947e7e")
+        );
+        assert_eq!(
+            STACK_WALK_GUID,
+            GUID::from("def2fe46-7bd6-4b80-bd94-f57fe20d0ce3")
+        );
+        assert_eq!(
+            EVENT_TRACE_GUID,
+            GUID::from("68fdd900-4a3e-11d1-84f4-0000f80464e3")
+        );
+        assert_eq!(
+            MMCSS_TRACE_GUID,
+            GUID::from("f8f10121-b617-4a56-868b-9df1b27fe32c")
+        );
+        assert_eq!(
+            SYSTEM_TRACE_GUID,
+            GUID::from("9e814aad-3204-11d2-9a82-006008a86939")
+        );
+        assert_eq!(
+            EVENT_TRACE_CONFIG_GUID,
+            GUID::from("01853a65-418f-4f36-aefc-dc0f1d2fd235")
+        );
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,55 @@
+//! ETW information classes wrapper
+
+use windows::Win32::System::Diagnostics::Etw::TRACE_PROFILE_INTERVAL;
+use zerocopy::AsBytes;
+
+use crate::{
+    native::{etw_types::TraceInformation, evntrace},
+    trace::TraceError,
+};
+
+type TraceResult<T> = Result<T, TraceError>;
+
+#[repr(u32)]
+pub enum ProfileSource {
+    ProfileTime = 0,
+}
+
+pub struct SessionInfo<'a>(&'a mut evntrace::NativeEtw);
+
+impl SessionInfo<'_> {}
+
+pub struct SessionlessInfo;
+
+impl SessionlessInfo {
+    pub fn sample_interval(source: ProfileSource) -> TraceResult<u32> {
+        let mut info = TRACE_PROFILE_INTERVAL {
+            Source: source as u32,
+            Interval: 0,
+        };
+
+        evntrace::query_info(
+            TraceInformation::TraceSampledProfileIntervalInfo,
+            // SAFETY: TRACE_PROFILE_INTERVAL is `#[repr(C)]` and uses only POD
+            unsafe {
+                std::slice::from_raw_parts_mut(
+                    &mut info as *mut _ as *mut u8,
+                    std::mem::size_of::<TRACE_PROFILE_INTERVAL>(),
+                )
+            },
+        )?;
+
+        Ok(info.Interval)
+    }
+
+    pub fn max_pmc() -> TraceResult<u32> {
+        let mut max_pmc = 0u32;
+
+        evntrace::query_info(
+            TraceInformation::TraceMaxPmcCounterQuery,
+            max_pmc.as_bytes_mut(),
+        )?;
+
+        Ok(max_pmc)
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,6 @@
 //! ETW information classes wrapper
 
-use windows::Win32::System::Diagnostics::Etw::{PROFILE_SOURCE_INFO, TRACE_PROFILE_INTERVAL};
+use windows::Win32::System::Diagnostics::Etw::TRACE_PROFILE_INTERVAL;
 
 use memoffset::offset_of;
 use std::convert::TryInto;
@@ -14,6 +14,7 @@ use crate::{
 type TraceResult<T> = Result<T, TraceError>;
 
 #[allow(non_camel_case_types)]
+#[allow(non_snake_case)]
 mod ffi {
     #[repr(C)]
     #[derive(zerocopy::AsBytes, zerocopy::FromBytes)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,10 @@
 //! ETW information classes wrapper
 
-use windows::Win32::System::Diagnostics::Etw::TRACE_PROFILE_INTERVAL;
-use zerocopy::AsBytes;
+use windows::Win32::System::Diagnostics::Etw::{PROFILE_SOURCE_INFO, TRACE_PROFILE_INTERVAL};
+
+use memoffset::offset_of;
+use std::convert::TryInto;
+use zerocopy::{AsBytes, FromBytes};
 
 use crate::{
     native::{etw_types::TraceInformation, evntrace},
@@ -10,9 +13,31 @@ use crate::{
 
 type TraceResult<T> = Result<T, TraceError>;
 
+#[allow(non_camel_case_types)]
+mod ffi {
+    #[repr(C)]
+    #[derive(zerocopy::AsBytes, zerocopy::FromBytes)]
+    pub struct PROFILE_SOURCE_INFO {
+        pub NextEntryOffset: u32,
+        pub Source: u32,
+        pub MinInterval: u32,
+        pub MaxInterval: u32,
+        pub Reserved: u64,
+        pub Description: [u16; 4], // Sized until next entry
+    }
+}
+
 #[repr(u32)]
 pub enum ProfileSource {
     ProfileTime = 0,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileSourceInfo {
+    pub id: u32,
+    pub min_interval: u32,
+    pub max_interval: u32,
+    pub description: String,
 }
 
 pub struct SessionInfo<'a>(&'a mut evntrace::NativeEtw);
@@ -51,5 +76,53 @@ impl SessionlessInfo {
         )?;
 
         Ok(max_pmc)
+    }
+
+    pub fn profile_sources() -> TraceResult<Vec<ProfileSourceInfo>> {
+        let mut memblk = [0u8; 8192];
+        let mut memblk = {
+            let len =
+                evntrace::query_info(TraceInformation::TraceProfileSourceListInfo, &mut memblk)?;
+            &memblk[..len]
+        };
+
+        let mut sources = Vec::new();
+
+        while !memblk.is_empty() {
+            let source_info = match ffi::PROFILE_SOURCE_INFO::read_from_prefix(memblk) {
+                Some(si) => si,
+                None => break,
+            };
+
+            let desc_end = match source_info.NextEntryOffset {
+                0 => memblk.len(),
+                n => n as usize,
+            };
+
+            let desc = &memblk[offset_of!(ffi::PROFILE_SOURCE_INFO, Description)..desc_end];
+            let desc = desc
+                .chunks_exact(2)
+                // Filter out the NULL terminator.
+                .filter_map(|c| match u16::from_ne_bytes(c.try_into().unwrap()) {
+                    0 => None,
+                    n => Some(n),
+                })
+                .collect::<Vec<_>>();
+
+            sources.push(ProfileSourceInfo {
+                id: source_info.Source,
+                min_interval: source_info.MinInterval,
+                max_interval: source_info.MaxInterval,
+                description: String::from_utf16_lossy(&desc),
+            });
+
+            if source_info.NextEntryOffset == 0 {
+                break;
+            }
+
+            memblk = &memblk[source_info.NextEntryOffset as usize..];
+        }
+
+        Ok(sources)
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -114,7 +114,7 @@ impl SchemaLocator {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     /// };
     /// ```
@@ -172,7 +172,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let event_id = schema.event_id();
     /// };
@@ -187,7 +187,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let event_id = schema.opcode();
     /// };
@@ -202,7 +202,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let event_flags = schema.event_flags();
     /// };
@@ -217,7 +217,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let event_version = schema.event_version();
     /// };
@@ -232,7 +232,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let pid = schema.process_id();
     /// };
@@ -247,7 +247,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let tid = schema.thread_id();
     /// };
@@ -269,7 +269,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let timestamp = schema.timestamp();
     /// };
@@ -285,7 +285,7 @@ impl Schema {
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
     ///
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let activity_id = schema.activity_id();
     /// };
@@ -304,7 +304,7 @@ impl Schema {
     /// # use ferrisetw::schema::SchemaLocator;
     /// use windows::Win32::System::Diagnostics::Etw::EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID;
     ///
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let activity_id = schema
     ///         .extended_data()
@@ -340,7 +340,7 @@ impl Schema {
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
 
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let decoding_source = schema.decoding_source();
     /// };
@@ -356,7 +356,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let provider_name = schema.provider_name();
     /// };
@@ -373,7 +373,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let task_name = schema.task_name();
     /// };
@@ -390,7 +390,7 @@ impl Schema {
     /// ```
     /// # use ferrisetw::native::etw_types::EventRecord;
     /// # use ferrisetw::schema::SchemaLocator;
-    /// let my_callback = |record: EventRecord, schema_locator: &mut SchemaLocator| {
+    /// let my_callback = |record: &mut EventRecord, schema_locator: &mut SchemaLocator| {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     ///     let opcode_name = schema.opcode_name();
     /// };

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -81,7 +81,7 @@ impl SchemaKey {
 /// * EventHeader.EventDescriptor.Level
 ///
 /// Credits: [KrabsETW::schema_locator](https://github.com/microsoft/krabsetw/blob/master/krabs/krabs/schema_locator.hpp).
-/// See also the [`SchemaKey`] for more info
+/// See also the code of `SchemaKey` for more info
 #[derive(Default)]
 pub struct SchemaLocator {
     schemas: HashMap<SchemaKey, Arc<TraceEventInfoRaw>>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -118,7 +118,7 @@ impl SchemaLocator {
     ///     let schema = schema_locator.event_schema(record).unwrap();
     /// };
     /// ```
-    pub fn event_schema(&mut self, event: EventRecord) -> SchemaResult<Schema> {
+    pub fn event_schema(&mut self, event: &mut EventRecord) -> SchemaResult<Schema> {
         let key = SchemaKey::new(&event);
         let info: Arc<_>;
 
@@ -130,7 +130,7 @@ impl SchemaLocator {
             info = Arc::clone(self.schemas.get(&key).unwrap());
         }
 
-        Ok(Schema::new(event, info))
+        Ok(Schema::new(event.clone(), info))
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -325,10 +325,10 @@ impl Schema {
         unsafe {
             std::slice::from_raw_parts(
                 p_ed_array as *const EventHeaderExtendedDataItem,
-                n_extended_data as usize)
+                n_extended_data as usize,
+            )
         }
     }
-
 
     /// Use the `decoding_source` function to obtain the [DecodingSource] from the [TraceEventInfo]
     ///

--- a/src/schema/extended_data.rs
+++ b/src/schema/extended_data.rs
@@ -1,29 +1,23 @@
 //! A module to handle Extended Data from ETW traces
 
 use windows::core::GUID;
-use windows::Win32::System::Diagnostics::Etw::{
-    EVENT_HEADER_EXTENDED_DATA_ITEM,
-    EVENT_HEADER_EXT_TYPE_SID,
-    EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID,
-    EVENT_HEADER_EXT_TYPE_TS_ID,
-    EVENT_HEADER_EXT_TYPE_INSTANCE_INFO,
-    EVENT_HEADER_EXT_TYPE_STACK_TRACE32,
-    EVENT_HEADER_EXT_TYPE_STACK_TRACE64,
-    EVENT_HEADER_EXT_TYPE_EVENT_KEY,
-    EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY,
-};
-use windows::Win32::System::Diagnostics::Etw::{
-    EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID,
-    EVENT_EXTENDED_ITEM_TS_ID,
-    EVENT_EXTENDED_ITEM_INSTANCE,
-    EVENT_EXTENDED_ITEM_STACK_TRACE32,
-    EVENT_EXTENDED_ITEM_STACK_TRACE64,
-};
 use windows::Win32::Security::SID;
+use windows::Win32::System::Diagnostics::Etw::{
+    EVENT_EXTENDED_ITEM_INSTANCE, EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID,
+    EVENT_EXTENDED_ITEM_STACK_TRACE32, EVENT_EXTENDED_ITEM_STACK_TRACE64,
+    EVENT_EXTENDED_ITEM_TS_ID,
+};
+use windows::Win32::System::Diagnostics::Etw::{
+    EVENT_HEADER_EXTENDED_DATA_ITEM, EVENT_HEADER_EXT_TYPE_EVENT_KEY,
+    EVENT_HEADER_EXT_TYPE_INSTANCE_INFO, EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY,
+    EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID, EVENT_HEADER_EXT_TYPE_SID,
+    EVENT_HEADER_EXT_TYPE_STACK_TRACE32, EVENT_HEADER_EXT_TYPE_STACK_TRACE64,
+    EVENT_HEADER_EXT_TYPE_TS_ID,
+};
 
 /// A wrapper over [`windows::Win32::System::Diagnostics::Etw::EVENT_HEADER_EXTENDED_DATA_ITEM`]
 #[repr(transparent)]
-pub struct EventHeaderExtendedDataItem (EVENT_HEADER_EXTENDED_DATA_ITEM);
+pub struct EventHeaderExtendedDataItem(EVENT_HEADER_EXTENDED_DATA_ITEM);
 
 /// A safe representation of an ExtendedDataItem
 ///
@@ -72,42 +66,42 @@ impl EventHeaderExtendedDataItem {
         match self.0.ExtType as u32 {
             EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID;
-                ExtendedDataItem::RelatedActivityId( unsafe{ *data_ptr }.RelatedActivityId )
+                ExtendedDataItem::RelatedActivityId(unsafe { *data_ptr }.RelatedActivityId)
             }
 
             EVENT_HEADER_EXT_TYPE_SID => {
                 let data_ptr = data_ptr as *const SID;
-                ExtendedDataItem::Sid( unsafe{ *data_ptr } )
+                ExtendedDataItem::Sid(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_TS_ID => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_TS_ID;
-                ExtendedDataItem::TsId( unsafe{ *data_ptr }.SessionId )
+                ExtendedDataItem::TsId(unsafe { *data_ptr }.SessionId)
             }
 
             EVENT_HEADER_EXT_TYPE_INSTANCE_INFO => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_INSTANCE;
-                ExtendedDataItem::InstanceInfo( unsafe{ *data_ptr } )
+                ExtendedDataItem::InstanceInfo(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_STACK_TRACE32 => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_STACK_TRACE32;
-                ExtendedDataItem::StackTrace32( unsafe{ *data_ptr } )
+                ExtendedDataItem::StackTrace32(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_STACK_TRACE64 => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_STACK_TRACE64;
-                ExtendedDataItem::StackTrace64( unsafe{ *data_ptr } )
+                ExtendedDataItem::StackTrace64(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY => {
                 let data_ptr = data_ptr as *const u64;
-                ExtendedDataItem::ProcessStartKey( unsafe{ *data_ptr } )
+                ExtendedDataItem::ProcessStartKey(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_EVENT_KEY => {
                 let data_ptr = data_ptr as *const u64;
-                ExtendedDataItem::EventKey( unsafe{ *data_ptr } )
+                ExtendedDataItem::EventKey(unsafe { *data_ptr })
             }
 
             _ => ExtendedDataItem::Unsupported,

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -7,7 +7,7 @@ use crate::native::{evntrace, version_helper};
 use crate::provider::Provider;
 use crate::{provider, schema, utils};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Mutex, RwLock};
+use std::sync::Mutex;
 use windows::core::GUID;
 
 const KERNEL_LOGGER_NAME: &str = "NT Kernel Logger";

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -98,11 +98,6 @@ impl TraceData {
         self.providers.push(provider);
     }
 
-    // TODO: Evaluate Multi-threading
-    pub(crate) unsafe fn unsafe_get_callback_ctx<'a>(ctx: *mut std::ffi::c_void) -> &'a Self {
-        &*(ctx as *mut TraceData)
-    }
-
     pub(crate) fn on_event(&self, record: EventRecord) {
         self.events_handled.fetch_add(1, Ordering::Relaxed);
         let mut locator = self.schema_locator.lock().unwrap();

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -405,7 +405,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Can't enable Provider with no GUID")]
+    #[should_panic(expected = "Attempted to enable provider with no GUID")]
     fn test_provider_no_guid_should_panic() {
         let prov = Provider::new();
 


### PR DESCRIPTION
1) Add a trace builder to clearly separate operations that are only valid at build-time vs. ones that can be performed on a live session
2) Remove the internal worker thread, preferring to expose that to end-users so that they may decide how to begin processing a trace. Also todo - expose start/end times from `ProcessTrace` in the API
3) Basic support for querying/setting trace information, and add an example of dumping all profile sources in the system