### PR TITLE
Improved safety

### DIFF
--- a/examples/kernel_trace.rs
+++ b/examples/kernel_trace.rs
@@ -15,9 +15,9 @@ fn main() {
                 if opcode == 10 {
                     let name = schema.provider_name();
                     println!("ProviderName: {}", name);
-                    let mut parser = Parser::create(record, &schema);
+                    let parser = Parser::create(record, &schema);
                     // Fully Qualified Syntax for Disambiguation
-                    match TryParse::<String>::try_parse(&mut parser, "FileName") {
+                    match TryParse::<String>::try_parse(&parser, "FileName") {
                         Ok(filename) => println!("FileName: {}", filename),
                         Err(err) => println!("Error: {:?} getting Filename", err),
                     };

--- a/examples/multiple_providers.rs
+++ b/examples/multiple_providers.rs
@@ -10,7 +10,7 @@ fn registry_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
     match schema_locator.event_schema(record) {
         Ok(schema) => {
             if record.event_id() == 7 {
-                let mut parser = Parser::create(record, &schema);
+                let parser = Parser::create(record, &schema);
                 let pid = record.process_id();
                 let key_obj: Pointer = parser.try_parse("KeyObject").unwrap_or(Pointer::default());
                 let status: u32 = parser.try_parse("Status").unwrap_or(0);
@@ -29,7 +29,7 @@ fn tcpip_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
     match schema_locator.event_schema(record) {
         Ok(schema) => {
             if record.event_id() == 11 {
-                let mut parser = Parser::create(record, &schema);
+                let parser = Parser::create(record, &schema);
                 let size: u32 = parser.try_parse("size").unwrap_or(0);
                 let daddr: IpAddr = parser
                     .try_parse("daddr")

--- a/examples/user_trace.rs
+++ b/examples/user_trace.rs
@@ -15,7 +15,7 @@ fn main() {
                 if event_id == 2 {
                     let name = schema.provider_name();
                     println!("Name: {}", name);
-                    let mut parser = Parser::create(record, &schema);
+                    let parser = Parser::create(record, &schema);
                     let process_id: u32 = parser.try_parse("ProcessID").unwrap();
                     let exit_code: u32 = parser.try_parse("ExitCode").unwrap();
                     let image_name: String = parser.try_parse("ImageName").unwrap();

--- a/src/native/etw_types/event_record.rs
+++ b/src/native/etw_types/event_record.rs
@@ -31,6 +31,13 @@ impl EventRecord {
         &self.0 as *const EVENT_RECORD
     }
 
+    /// The `UserContext` field from the wrapped `EVENT_RECORD`
+    ///
+    /// In this crate, it is always populated to point to a valid [`TraceData`](crate::trace::TraceData)
+    pub fn user_context(&self) -> *const std::ffi::c_void {
+        self.0.UserContext as *const _
+    }
+
     /// The `ProviderId` field from the wrapped `EVENT_RECORD`
     pub fn provider_id(&self) -> GUID {
         self.0.EventHeader.ProviderId

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -40,10 +40,24 @@ impl From<std::io::Error> for EvntraceNativeError {
 
 pub(crate) type EvntraceNativeResult<T> = Result<T, EvntraceNativeError>;
 
-unsafe extern "system" fn trace_callback_thunk(p_record: *mut Etw::EVENT_RECORD) {
-    let ctx: &mut TraceData = TraceData::unsafe_get_callback_ctx((*p_record).UserContext);
-    if let Some(event_record) = EventRecord::from_ptr(p_record) {
-        ctx.on_event(event_record);
+extern "system" fn trace_callback_thunk(p_record: *mut Etw::EVENT_RECORD) {
+    let record_from_ptr = unsafe {
+        // Safety: lifetime is valid at least until the end of the callback. A correct lifetime will be attached when we pass the reference to the child function
+        EventRecord::from_ptr(p_record)
+    };
+
+    if let Some(event_record) = record_from_ptr {
+        let p_user_context = event_record.user_context().cast::<TraceData>();
+        let user_context = unsafe {
+            // Safety:
+            //  * the API of this create guarantees this points to a `TraceData` already allocated and created
+            //  * TODO (#45): the API of this crate does not yet guarantee this `TraceData` is not mutated during the trace (e.g. modifying the list of providers) (although this may not be critical memory-safety-wise)
+            //  * TODO (#45): the API of this create does not yet guarantee this `TraceData` has not been dropped
+            p_user_context.as_ref()
+        };
+        if let Some(user_context) = user_context {
+            user_context.on_event(event_record);
+        }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -301,7 +301,7 @@ impl_try_parse_primitive!(isize);
 /// # use ferrisetw::parser::{Parser, TryParse};
 /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
 ///     let schema = schema_locator.event_schema(record).unwrap();
-///     let mut parser = Parser::create(record, &schema);
+///     let parser = Parser::create(record, &schema);
 ///     let image_name: String = parser.try_parse("ImageName").unwrap();
 /// };
 /// ```


### PR DESCRIPTION
A few tweaks to make ferrisetw slightly less `unsafe`.

Also, we're now using `catch_unwind` to avoid undefined behaviour at a C/Rust boundary