### PR TITLE
Fixed error code handling

### DIFF
--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -144,7 +144,9 @@ impl NativeEtw {
             if status == ERROR_ALREADY_EXISTS.0 {
                 return Err(EvntraceNativeError::AlreadyExist);
             } else if status != 0 {
-                return Err(EvntraceNativeError::IoError(std::io::Error::last_os_error()));
+                return Err(EvntraceNativeError::IoError(
+                    std::io::Error::from_raw_os_error(status as i32),
+                ));
             }
         }
         Ok(())
@@ -219,8 +221,8 @@ impl NativeEtw {
         level: u8,
         parameters: EnableTraceParameters,
     ) -> EvntraceNativeResult<()> {
-        unsafe {
-            if Etw::EnableTraceEx2(
+        match unsafe {
+            Etw::EnableTraceEx2(
                 self.registration_handle,
                 &guid,
                 1, // Fixme: EVENT_CONTROL_CODE_ENABLE_PROVIDER
@@ -229,11 +231,12 @@ impl NativeEtw {
                 all,
                 0,
                 parameters.as_ptr(),
-            ) != 0
-            {
-                return Err(EvntraceNativeError::IoError(std::io::Error::last_os_error()));
+            )
+        } {
+            0 => Ok(()),
+            e => Err(EvntraceNativeError::IoError(
+                std::io::Error::from_raw_os_error(e as i32),
+            )),
             }
-        }
-        Ok(())
     }
 }

--- a/src/native/tdh.rs
+++ b/src/native/tdh.rs
@@ -87,7 +87,7 @@ impl TraceEventInfo {
             )
         };
         if status != ERROR_INSUFFICIENT_BUFFER.0 {
-            return Err(TdhNativeError::IoError(std::io::Error::last_os_error()));
+            return Err(TdhNativeError::IoError(std::io::Error::from_raw_os_error(status as i32)));
         }
 
         if buffer_size == 0 {
@@ -117,7 +117,7 @@ impl TraceEventInfo {
         };
 
         if status != 0 {
-            return Err(TdhNativeError::IoError(std::io::Error::last_os_error()));
+            return Err(TdhNativeError::IoError(std::io::Error::from_raw_os_error(status as i32)));
         }
 
         Ok(Self { data, mut_data_for_dealloc: data, layout })


### PR DESCRIPTION
Because some APIs return their error directly without the need to call `GetLastError`