### PR TITLE
fix parsing of wide strings

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -188,18 +188,16 @@ impl<'schema, 'record> Parser<'schema, 'record> {
                             },
 
                             TdhInType::InTypeUnicodeString => {
-                                let wide_slice = slice_of_u16(remaining_user_buffer)?;
-
                                 let mut l = 0;
-                                for wchar in wide_slice {
-                                    if wchar == &0 {
-                                        l += 1; // include the final null wchar
+                                for bytes in remaining_user_buffer.chunks_exact(2) {
+                                    if bytes[0] == 0 && bytes[1] == 0 {
+                                        l += 2;
                                         break;
                                     }
-                                    l += 1;
+                                    l += 2;
                                 }
-                                return Ok(2 * l)
-                            },
+                                return Ok(l);
+                            }
 
                             _ => (),
                         }
@@ -314,10 +312,15 @@ impl TryParse<String> for Parser<'_, '_> {
         // TODO: Handle errors and type checking better
         let res = match prop_slice.property.in_type() {
             TdhInType::InTypeUnicodeString => {
-                let wide_slice = slice_of_u16(prop_slice.buffer)?;
-                match U16CStr::from_slice(wide_slice) {
-                    Err(_) => return Err(ParserError::PropertyError("Widestring is not null-terminated".into())),
-                    Ok(s) => s.to_string_lossy()
+                let wide_vec = bytes_to_u16_vec(prop_slice.buffer)?;
+
+                match U16CStr::from_slice(&wide_vec) {
+                    Err(_) => {
+                        return Err(ParserError::PropertyError(
+                            "Widestring is not null-terminated".into(),
+                        ))
+                    }
+                    Ok(s) => s.to_string_lossy(),
                 }
             }
             TdhInType::InTypeAnsiString => std::str::from_utf8(prop_slice.buffer)?
@@ -441,71 +444,44 @@ impl TryParse<Vec<u8>> for Parser<'_, '_> {
 // TODO: Implement SocketAddress
 // TODO: Study if we can use primitive types for HexInt64, HexInt32 and Pointer
 
-fn slice_of_u16(input: &[u8]) -> ParserResult<&[u16]> {
+fn bytes_to_u16_vec(input: &[u8]) -> ParserResult<Vec<u16>> {
     if input.len() % 2 != 0 {
-        return Err(ParserError::PropertyError("odd length in bytes for a widestring".into()));
+        return Err(ParserError::PropertyError(
+            "odd length in bytes for a widestring".into(),
+        ));
     }
 
-    let wide_ptr = input.as_ptr() as *const u16;
-    let wide_len = input.len() / 2;
-
-    if wide_ptr.is_null() || is_aligned_to_u16(wide_ptr) == false {
-        return Err(ParserError::PropertyError("Invalid widestring pointer".into()));
+    let mut res = Vec::with_capacity(input.len() / 2);
+    for wide_slice in input.chunks_exact(2) {
+        let two_bytes = wide_slice.try_into().unwrap();
+        res.push(u16::from_le_bytes(two_bytes));
     }
 
-    // Safety: we've just checked the pointer is
-    //  * non-null
-    //  * correctly aligned
-    // Note: that's OK to build zero-sized slices
-    let s = unsafe {
-        std::slice::from_raw_parts(wide_ptr, wide_len)
-    };
-    Ok(s)
-}
-
-fn is_aligned_to_u16<T>(p: *const T) -> bool {
-    // ptr::is_aligned is not stable. Let's implement our own
-    let addr = p as usize;
-    addr % 2 == 0
+    Ok(res)
 }
 
 
 #[cfg(test)]
 mod test {
-    use super::slice_of_u16;
-
-    // #[repr(align("16"))] does not support arrays
-    // Using a hack to make sure the array is aligned, inspired from https://users.rust-lang.org/t/aligning-a-u8-array-to-16-bytes/7560/2
-    struct My16BitAlignedU8Array<const N: usize> {
-        data: [u8; N],
-        _alignment: [u16; 0],
-    }
-    impl<const N: usize> My16BitAlignedU8Array<N> {
-        fn new(data: [u8;N]) -> Self {
-            Self { data, _alignment: [] }
-        }
-    }
-
+    use super::bytes_to_u16_vec;
 
     #[test]
-    fn test_slice_of_u16() {
-        let unicode_array = My16BitAlignedU8Array::new(
-            [0xd8,0, 0x20,0, 0x8c,1, 0xeb,0, 0x61,0, 0x72,0, 0,0]
-        );
+    fn test_bytes_to_u16_vec() {
+        let unicode_array: [u8; 14] =     [0xd8,0, 0x20,0, 0x8c,1, 0xeb,0, 0x61,0, 0x72,0, 0,0];
         let expected_u16_array: [u16;7] = [0xd8,   0x20,   0x18c,  0xeb,   0x61,   0x72,   0];
 
-        let u16_slice = slice_of_u16(&unicode_array.data).unwrap();
+        let u16_slice = bytes_to_u16_vec(&unicode_array).unwrap();
         let decoded_string = widestring::ucstr::U16CStr::from_slice(&u16_slice).unwrap().to_string().unwrap();
 
-        assert_eq!(slice_of_u16(&unicode_array.data).unwrap(), &expected_u16_array);
+        assert_eq!(bytes_to_u16_vec(&unicode_array).unwrap(), &expected_u16_array);
         assert_eq!(&decoded_string, "Ø ƌëar");
 
 
-        let empty_array = My16BitAlignedU8Array::new([]);
-        assert_eq!(slice_of_u16(&empty_array.data).unwrap(), &[]);
+        let empty_array = [];
+        assert_eq!(bytes_to_u16_vec(&empty_array).unwrap(), &[]);
 
 
-        let odd_length_array = My16BitAlignedU8Array::new([1,2,3]);
-        assert!(slice_of_u16(&odd_length_array.data).is_err());
+        let odd_length_array = [1,2,3];
+        assert!(bytes_to_u16_vec(&odd_length_array).is_err());
     }
 }


### PR DESCRIPTION
This fixes https://github.com/n4r1b/ferrisetw/issues/60

There is no guarantee the wide string pointer is aligned, and thus the vec of u16 values must be reconstructed, there is no way to avoid it. The previous rejection on unaligned pointers led to failing to parse valid values.

Thanks to @vthib for this fix