### PR TITLE
Turbofish operator for try_parse

### DIFF
--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -8,7 +8,6 @@ use ferrisetw::parser::Parser;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::native::etw_types::EventRecord;
 use ferrisetw::trace::UserTrace;
-use ferrisetw::parser::TryParse;
 use ferrisetw::schema::Schema;
 
 

--- a/examples/kernel_trace.rs
+++ b/examples/kernel_trace.rs
@@ -1,5 +1,5 @@
 use ferrisetw::native::etw_types::EventRecord;
-use ferrisetw::parser::{Parser, TryParse};
+use ferrisetw::parser::Parser;
 use ferrisetw::provider::*;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::*;
@@ -17,7 +17,7 @@ fn main() {
                     println!("ProviderName: {}", name);
                     let parser = Parser::create(record, &schema);
                     // Fully Qualified Syntax for Disambiguation
-                    match TryParse::<String>::try_parse(&parser, "FileName") {
+                    match parser.try_parse::<String>("FileName") {
                         Ok(filename) => println!("FileName: {}", filename),
                         Err(err) => println!("Error: {:?} getting Filename", err),
                     };

--- a/examples/multiple_providers.rs
+++ b/examples/multiple_providers.rs
@@ -1,5 +1,5 @@
 use ferrisetw::native::etw_types::EventRecord;
-use ferrisetw::parser::{Parser, Pointer, TryParse};
+use ferrisetw::parser::{Parser, Pointer};
 use ferrisetw::provider::*;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::*;

--- a/examples/user_trace.rs
+++ b/examples/user_trace.rs
@@ -1,5 +1,5 @@
 use ferrisetw::native::etw_types::EventRecord;
-use ferrisetw::parser::{Parser, TryParse};
+use ferrisetw::parser::Parser;
 use ferrisetw::provider::*;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@
 //! use ferrisetw::native::etw_types::EventRecord;
 //! use ferrisetw::schema_locator::SchemaLocator;
 //! use ferrisetw::parser::Parser;
-//! use ferrisetw::parser::TryParse;
 //! use ferrisetw::provider::Provider;
 //! use ferrisetw::trace::{UserTrace, TraceTrait};
 //!
@@ -57,8 +56,7 @@
 //!                 // Finally, properties for a given event can be retrieved using a Parser
 //!                 let parser = Parser::create(record, &schema);
 //!
-//!                 // Type annotations or Fully Qualified Syntax are needed when calling TryParse
-//!                 // Supported types implement the trait TryParse for Parser
+//!                 // You'll need type inference to tell ferrisetw what type you want to parse into
 //!                 // In actual code, be sure to correctly handle Err values!
 //!                 let process_id: u32 = parser.try_parse("ProcessID").unwrap();
 //!                 let image_name: String = parser.try_parse("ImageName").unwrap();

--- a/src/native/tdh_types.rs
+++ b/src/native/tdh_types.rs
@@ -5,10 +5,9 @@
 //! event
 //!
 //! This is a bit extra but is basically a redefinition of the In an Out TDH types following the
-//! rust naming convention, it can also come in handy when implementing the [TryParse] trait for a type
+//! rust naming convention, it can also come in handy when implementing the `TryParse` trait for a type
 //! to determine how to handle a [Property] based on this values
 //!
-//! [TryParse]: crate::parser::TryParse
 //! [Property]: crate::native::tdh_types::Property
 use num_traits::FromPrimitive;
 

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -8,7 +8,7 @@ use ferrisetw::native::etw_types::EventRecord;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::UserTrace;
 use ferrisetw::trace::TraceTrait;
-use ferrisetw::parser::{Parser, TryParse};
+use ferrisetw::parser::Parser;
 
 mod utils;
 use utils::{Status, TestKind};
@@ -123,12 +123,12 @@ fn check_a_few_cases(record: &EventRecord, parser: &Parser) {
     // Parsing with a wrong type should properly error out
     if record.event_id() == EVENT_ID_DNS_QUERY_INITIATED {
         let _right_type: String = parser.try_parse("QueryName").unwrap();
-        let wrong_type: Result<u32, _> = parser.try_parse("QueryName");
+        let wrong_type = parser.try_parse::<u32>("QueryName");
         assert!(wrong_type.is_err());
     }
 
     // Giving an unknown property should properly error out
-    let wrong_name: Result<u32, _> = parser.try_parse("NoSuchProperty");
+    let wrong_name = parser.try_parse::<u32>("NoSuchProperty");
     assert!(wrong_name.is_err());
 }
 

--- a/tests/kernel_trace.rs
+++ b/tests/kernel_trace.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use ferrisetw::provider::{Provider, EventFilter};
 use ferrisetw::native::etw_types::EventRecord;
 use ferrisetw::schema_locator::SchemaLocator;
-use ferrisetw::parser::{Parser, TryParse};
+use ferrisetw::parser::Parser;
 use ferrisetw::trace::KernelTrace;
 use ferrisetw::provider::kernel_providers;
 
@@ -88,7 +88,7 @@ fn generate_image_load_events() {
 
 fn has_seen_dll_load(record: &EventRecord, parser: &Parser) -> bool {
     if record.process_id() == std::process::id() {
-        let filename: Result<String, _> = parser.try_parse("FileName");
+        let filename = parser.try_parse::<String>("FileName");
         println!("   this one's for us: {:?}", filename);
         if let Ok(filename) = filename {
             if filename.ends_with(TEST_LIBRARY_NAME) {


### PR DESCRIPTION
This PR depends on #63 and #65 , as its first commits come from them.

This makes it possible to use the turbofish operator for `try_parse`, which is slightly more convenient than the current solution.
This improvement was already considered by @n4r1b quite a long time ago, since there was a 
`// TODO: Find a way to use turbofish operator`