### PR TITLE
Check property flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,7 @@ zerocopy = "0.6"
 time = { version = "0.3", features = ["large-dates"], optional = true }
 # thiserror = "~1.0"
 # anyhow = "~1.0"
+log = "0.4"
+
+[dev-dependencies]
+env_logger = "0.9" # used in examples

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -66,6 +66,8 @@ fn parse_etw_event(schema: &Schema, record: &EventRecord) {
 }
 
 fn main() {
+    env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
+
     let dns_provider = Provider
         ::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
         .add_callback(dns_etw_callback)

--- a/examples/kernel_trace.rs
+++ b/examples/kernel_trace.rs
@@ -6,6 +6,8 @@ use ferrisetw::trace::*;
 use std::time::Duration;
 
 fn main() {
+    env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
+
     let image_load_callback =
         |record: &EventRecord, schema_locator: &SchemaLocator| match schema_locator
             .event_schema(record)

--- a/examples/multiple_providers.rs
+++ b/examples/multiple_providers.rs
@@ -50,6 +50,8 @@ fn tcpip_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
 }
 
 fn main() {
+    env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
+
     let tcpip_provider = Provider
         ::by_guid("7dd42a49-5329-4832-8dfd-43d979153a88") // Microsoft-Windows-Kernel-Network
         .add_callback(tcpip_callback)

--- a/examples/user_trace.rs
+++ b/examples/user_trace.rs
@@ -6,6 +6,8 @@ use ferrisetw::trace::*;
 use std::time::Duration;
 
 fn main() {
+    env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
+
     let process_callback =
         |record: &EventRecord, schema_locator: &SchemaLocator| match schema_locator
             .event_schema(record)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,11 @@
 //!
 //! [KrabsETW]: https://github.com/microsoft/krabsetw/
 //! [Source]: https://docs.microsoft.com/en-us/windows/win32/etw/about-event-tracing
+//!
+//! # Log messages
+//! ferrisetw may (very) occasionally write error log messages using the [`log`](https://docs.rs/log/latest/log/) crate.<br/>
+//! In case you want them to be printed to the console, your binary should use one of the various logger implementations. [`env_logger`](https://docs.rs/env_logger/latest/env_logger/) is one of them.<br/>
+//! You can have a look at how to use it in the `examples/` folder in the GitHub repository.
 
 #[macro_use]
 extern crate memoffset;

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -122,7 +122,7 @@ extern "system" fn trace_callback_thunk(p_record: *mut Etw::EVENT_RECORD) {
     })) {
         Ok(_) => {}
         Err(e) => {
-            eprintln!("UNIMPLEMENTED PANIC: {e:?}");
+            log::error!("UNIMPLEMENTED PANIC: {e:?}");
             std::process::exit(1);
         }
     }

--- a/src/native/pla.rs
+++ b/src/native/pla.rs
@@ -136,7 +136,6 @@ pub(crate) unsafe fn get_provider_guid(name: &str) -> ProvidersComResult<GUID> {
         if prov_name.eq(name) {
             hr = provider.get_guid(guid.as_mut_ptr());
             check_hr(hr)?;
-            println!("{}", prov_name);
             break;
         }
     }

--- a/src/native/tdh.rs
+++ b/src/native/tdh.rs
@@ -191,7 +191,7 @@ impl<'info> PropertyIterator<'info> {
 }
 
 impl<'info> Iterator for PropertyIterator<'info> {
-    type Item = Property;
+    type Item = Result<Property, crate::native::tdh_types::PropertyError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.next_index == self.count {

--- a/src/native/version_helper.rs
+++ b/src/native/version_helper.rs
@@ -89,7 +89,7 @@ pub fn is_win8_or_greater() -> bool {
     let res = match verify_system_version(6, 2, 0) {
         Ok(res) => res,
         Err(err) => {
-            println!("{:?}", err);
+            log::warn!("Unable ro verify system version: {:?}", err);
             true
         }
     };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,8 +23,10 @@ use windows::core::GUID;
 pub enum ParserError {
     /// No property has this name
     NotFound,
-    /// An invalid type...
+    /// An invalid type
     InvalidType,
+    /// Some properties are not supported by this crate (yet?)
+    UnsupportedProperties,
     /// Error parsing
     ParseError,
     /// Length mismatch when parsing a type

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,7 +3,7 @@
 //! This module contains the means needed to interact with the Schema of an ETW event
 use crate::native::etw_types::DecodingSource;
 use crate::native::tdh::TraceEventInfo;
-use crate::native::tdh_types::Property;
+use crate::native::tdh_types::{Property, PropertyError};
 use once_cell::sync::OnceCell;
 
 /// A schema suitable for parsing a given kind of event.
@@ -14,7 +14,7 @@ use once_cell::sync::OnceCell;
 /// with a few info parsed (and cached) out of it
 pub struct Schema {
     te_info: TraceEventInfo,
-    cached_properties: OnceCell<Vec<Property>>,
+    cached_properties: OnceCell<Result<Vec<Property>, PropertyError>>,
 }
 
 impl Schema {
@@ -99,9 +99,21 @@ impl Schema {
     ///
     /// This is parsed on first call, and cached for later use
     pub(crate) fn properties(&self) -> &[Property] {
-        self.cached_properties.get_or_init(|| {
-            self.te_info.properties().collect()
-        })
+        let cache = self.cached_properties.get_or_init(|| {
+            let mut cache = Vec::new();
+            for property in self.te_info.properties() {
+                cache.push(property?)
+            }
+            Ok(cache)
+        });
+
+        match cache {
+            Err(PropertyError::UnimplementedType) => {
+                log::error!("Unable to list properties: a type is not implemented");
+                &[]
+            }
+            Ok(cache) => cache.as_slice()
+        }
     }
 }
 


### PR DESCRIPTION
This depends on #75 .

This improves the `// Fixme: Check flags to see which values to get for the in_type`.
We're now checking an properly returning an error in case we do not support a property.

That's better than the current situation, but we could one day implement missing property types (that's #76)