### PR TITLE
ETL file support

### DIFF
--- a/examples/file_trace.rs
+++ b/examples/file_trace.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("See tests/file_trace.rs for an example that dumps to and reads from an ETL file");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ pub mod trace;
 mod traits;
 mod utils;
 
+pub(crate) type EtwCallback = Box<dyn FnMut(&EventRecord, &SchemaLocator) + Send + Sync + 'static>;
+
 // Convenience re-exports.
 pub use crate::trace::UserTrace;
 pub use crate::trace::KernelTrace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@
 //!     let process_provider = Provider
 //!         ::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
 //!         .add_callback(process_callback)
-//!         // .add_filter(event_filters) // it is possible to filter by event ID, process ID, etc.
+//!         // .add_callback(process_callback) // it is possible to add multiple callbacks for a given provider
+//!         // .add_filter(event_filters)      // it is possible to filter by event ID, process ID, etc.
 //!         .build();
 //!
 //!     // We start a trace session for the previously registered provider
@@ -80,6 +81,7 @@
 //!         .named(String::from("MyTrace"))
 //!         .enable(process_provider)
 //!         // .enable(other_provider) // It is possible to enable multiple providers on the same trace.
+//!         // .set_etl_dump_file(...) // It is possible to dump the events that the callbacks are processing into a file
 //!         .start_and_process()       // This call will spawn the thread for you.
 //!                                    // See the doc for alternative ways of processing the trace,
 //!                                    // with more or less flexibility regarding this spawned thread.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,8 @@
 //! * Consumers
 //!
 //! This crate provides the means to start and stop a controller, enable/disable providers and
-//! finally to consume the events within our own defined callback.
+//! finally to consume the events within our own defined callback.<br/>
+//! It is also able to process events from a file instead of a real-time trace session.
 //!
 //! # Motivation
 //! Even though ETW is a extremely powerful tracing mechanism, interacting with it is not easy by any
@@ -75,7 +76,7 @@
 //!         // .add_filter(event_filters)      // it is possible to filter by event ID, process ID, etc.
 //!         .build();
 //!
-//!     // We start a trace session for the previously registered provider
+//!     // We start a real-time trace session for the previously registered provider
 //!     // Callbacks will be run in a separate thread.
 //!     let mut trace = UserTrace::new()
 //!         .named(String::from("MyTrace"))
@@ -128,6 +129,7 @@ pub(crate) type EtwCallback = Box<dyn FnMut(&EventRecord, &SchemaLocator) + Send
 // Convenience re-exports.
 pub use crate::trace::UserTrace;
 pub use crate::trace::KernelTrace;
+pub use crate::trace::FileTrace;
 pub use crate::native::etw_types::event_record::EventRecord;
 pub use crate::schema_locator::SchemaLocator;
 

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -177,6 +177,8 @@ impl std::default::Default for DumpFileLoggingMode {
 pub enum SubscriptionSource{
     /// Subscribe to a real-time session
     RealTimeSession(U16CString),
+    /// Open an ETL file
+    FromFile(U16CString),
 }
 
 /// Wrapper over an [EVENT_TRACE_PROPERTIES](https://docs.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties), and its allocated companion members
@@ -343,7 +345,14 @@ impl<'callbackdata> EventTraceLogfile<'callbackdata> {
                     // In case you really want to use PROCESS_TRACE_MODE_RAW_TIMESTAMP, please review EventRecord::timestamp(), which could not be valid anymore
                 };
             },
-        }
+            SubscriptionSource::FromFile(wide_file_name) => {
+                log_file.native.LogFileName = PWSTR(wide_file_name.as_mut_ptr());
+
+                log_file.native.Anonymous1 = Etw::EVENT_TRACE_LOGFILEW_0 {
+                    ProcessTraceMode: Etw::PROCESS_TRACE_MODE_EVENT_RECORD
+                    // In case you really want to use PROCESS_TRACE_MODE_RAW_TIMESTAMP, please review EventRecord::timestamp(), which could not be valid anymore
+                };
+            }
         }
 
         log_file

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -169,7 +169,7 @@ impl EventTraceProperties {
         // etw_trace_properties.LogFileNameOffset must be 0, but this will change when https://github.com/n4r1b/ferrisetw/issues/7 is resolved
         // > If you do not want to log events to a log file (for example, if you specify EVENT_TRACE_REAL_TIME_MODE only), set LogFileNameOffset to 0.
         // (https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties)
-        etw_trace_properties.LoggerNameOffset = offset_of!(EventTraceProperties, wide_log_file_name) as u32;
+        etw_trace_properties.LoggerNameOffset = offset_of!(EventTraceProperties, wide_trace_name) as u32;
 
         // https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties#remarks
         // > You do not copy the session name to the offset. The StartTrace function copies the name for you.

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -8,7 +8,7 @@
 //! needed by using the functions exposed by the modules at the crate level
 use crate::provider::event_filter::EventFilterDescriptor;
 use crate::provider::TraceFlags;
-use crate::trace::{TraceProperties, TraceTrait};
+use crate::trace::{TraceProperties, RealTimeTraceTrait};
 use crate::trace::callback_data::CallbackData;
 use std::ffi::{c_void, OsString};
 use std::fmt::Formatter;
@@ -210,7 +210,7 @@ impl EventTraceProperties {
         enable_flags: Etw::EVENT_TRACE_FLAG,
     ) -> Self
     where
-        T: TraceTrait
+        T: RealTimeTraceTrait
     {
         let mut etw_trace_properties = Etw::EVENT_TRACE_PROPERTIES::default();
 

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -77,25 +77,28 @@ pub(crate) enum ControlValues {
 }
 
 bitflags! {
-    /// Logging Mode constants
+    /// Logging Mode constants that applies to a general trace
     ///
-    /// See <https://learn.microsoft.com/en-us/windows/win32/etw/logging-mode-constants>
+    /// This is a subset of <https://learn.microsoft.com/en-us/windows/win32/etw/logging-mode-constants>
     pub struct LoggingMode: u32 {
-        const EVENT_TRACE_FILE_MODE_NONE =             Etw::EVENT_TRACE_FILE_MODE_NONE;
-        const EVENT_TRACE_FILE_MODE_SEQUENTIAL =       Etw::EVENT_TRACE_FILE_MODE_SEQUENTIAL;
-        const EVENT_TRACE_FILE_MODE_CIRCULAR =         Etw::EVENT_TRACE_FILE_MODE_CIRCULAR;
-        const EVENT_TRACE_FILE_MODE_APPEND =           Etw::EVENT_TRACE_FILE_MODE_APPEND;
-        const EVENT_TRACE_FILE_MODE_NEWFILE =          Etw::EVENT_TRACE_FILE_MODE_NEWFILE;
-        const EVENT_TRACE_FILE_MODE_PREALLOCATE =      Etw::EVENT_TRACE_FILE_MODE_PREALLOCATE;
+        // Commented values only apply to DumpFileLoggingMod
+
+        // EVENT_TRACE_FILE_MODE_NONE
+        // EVENT_TRACE_FILE_MODE_SEQUENTIAL
+        // EVENT_TRACE_FILE_MODE_CIRCULAR
+        // EVENT_TRACE_FILE_MODE_APPEND
+        // EVENT_TRACE_FILE_MODE_NEWFILE
+        // EVENT_TRACE_FILE_MODE_PREALLOCATE
         const EVENT_TRACE_NONSTOPPABLE_MODE =          Etw::EVENT_TRACE_NONSTOPPABLE_MODE;
         const EVENT_TRACE_SECURE_MODE =                Etw::EVENT_TRACE_SECURE_MODE;
         const EVENT_TRACE_REAL_TIME_MODE =             Etw::EVENT_TRACE_REAL_TIME_MODE;
-        const EVENT_TRACE_DELAY_OPEN_FILE_MODE =       Etw::EVENT_TRACE_DELAY_OPEN_FILE_MODE;
+        // On Windows Vista or later, this mode is not applicable should not be used.
+        // EVENT_TRACE_DELAY_OPEN_FILE_MODE
         const EVENT_TRACE_BUFFERING_MODE =             Etw::EVENT_TRACE_BUFFERING_MODE;
         const EVENT_TRACE_PRIVATE_LOGGER_MODE =        Etw::EVENT_TRACE_PRIVATE_LOGGER_MODE;
-        const EVENT_TRACE_USE_KBYTES_FOR_SIZE =        Etw::EVENT_TRACE_USE_KBYTES_FOR_SIZE;
-        const EVENT_TRACE_USE_GLOBAL_SEQUENCE =        Etw::EVENT_TRACE_USE_GLOBAL_SEQUENCE;
-        const EVENT_TRACE_USE_LOCAL_SEQUENCE =         Etw::EVENT_TRACE_USE_LOCAL_SEQUENCE;
+        // EVENT_TRACE_USE_KBYTES_FOR_SIZE
+        // EVENT_TRACE_USE_GLOBAL_SEQUENCE
+        // EVENT_TRACE_USE_LOCAL_SEQUENCE
         const EVENT_TRACE_PRIVATE_IN_PROC =            Etw::EVENT_TRACE_PRIVATE_IN_PROC;
         const EVENT_TRACE_MODE_RESERVED =              Etw::EVENT_TRACE_MODE_RESERVED;
         const EVENT_TRACE_STOP_ON_HYBRID_SHUTDOWN =    Etw::EVENT_TRACE_STOP_ON_HYBRID_SHUTDOWN;
@@ -108,6 +111,66 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// Logging Mode constants that applies to a dump file.
+    ///
+    /// This is a subset of <https://learn.microsoft.com/en-us/windows/win32/etw/logging-mode-constants>
+    ///
+    /// See the documentation of [`crate::trace::TraceBuilder::set_etl_dump_file`] for more info.
+    pub struct DumpFileLoggingMode: u32 {
+        // Commented values only apply to LoggingMode
+
+        /// > Same as EVENT_TRACE_FILE_MODE_SEQUENTIAL with no maximum file size specified.
+        const EVENT_TRACE_FILE_MODE_NONE =             Etw::EVENT_TRACE_FILE_MODE_NONE;
+        /// > Writes events to a log file sequentially; stops when the file reaches its maximum size.Do not use with EVENT_TRACE_FILE_MODE_CIRCULAR or EVENT_TRACE_FILE_MODE_NEWFILE.
+        ///
+        /// Note: "stop" here means "stop appending to the file", not "stop the trace"
+        const EVENT_TRACE_FILE_MODE_SEQUENTIAL =       Etw::EVENT_TRACE_FILE_MODE_SEQUENTIAL;
+        /// > Writes events to a log file. After the file reaches the maximum size, the oldest events are replaced with incoming events.Note that the contents of the circular log file may appear out of order on multiprocessor computers.<br/>
+        /// > Do not use with EVENT_TRACE_FILE_MODE_APPEND, EVENT_TRACE_FILE_MODE_NEWFILE, or EVENT_TRACE_FILE_MODE_SEQUENTIAL.
+        const EVENT_TRACE_FILE_MODE_CIRCULAR =         Etw::EVENT_TRACE_FILE_MODE_CIRCULAR;
+        /// > Appends events to an existing sequential log file. If the file does not exist, it is created. Use only if you specify system time for the clock resolution, otherwise, ProcessTrace will return events with incorrect time stamps. When using EVENT_TRACE_FILE_MODE_APPEND, the values for BufferSize, NumberOfProcessors, and ClockType must be explicitly provided and must be the same in both the logger and the file being appended.<br/>
+        /// > Do not use with EVENT_TRACE_REAL_TIME_MODE, EVENT_TRACE_FILE_MODE_CIRCULAR, EVENT_TRACE_FILE_MODE_NEWFILE, or EVENT_TRACE_PRIVATE_LOGGER_MODE.
+        const EVENT_TRACE_FILE_MODE_APPEND =           Etw::EVENT_TRACE_FILE_MODE_APPEND;
+        /// > Automatically switches to a new log file when the file reaches the maximum size. The MaximumFileSize member of EVENT_TRACE_PROPERTIES must be set.The specified file name must be a formatted string (for example, the string contains a %d, such as c:\test%d.etl). Each time a new file is created, a counter is incremented and its value is used, the formatted string is updated, and the resulting string is used as the file name.<br/>
+        /// > This option is not allowed for private event tracing sessions and should not be used for NT kernel logger sessions.<br/>
+        /// > Do not use with EVENT_TRACE_FILE_MODE_CIRCULAR, EVENT_TRACE_FILE_MODE_APPEND or EVENT_TRACE_FILE_MODE_SEQUENTIAL.
+        const EVENT_TRACE_FILE_MODE_NEWFILE =          Etw::EVENT_TRACE_FILE_MODE_NEWFILE;
+        /// > Reserves EVENT_TRACE_PROPERTIES.MaximumFileSize bytes of disk space for the log file in advance. The file occupies the entire space during logging, for both circular and sequential log files. When you stop the session, the log file is reduced to the size needed. You must set EVENT_TRACE_PROPERTIES.MaximumFileSize.<br/>
+        /// > You cannot use the mode for private event tracing sessions.
+        const EVENT_TRACE_FILE_MODE_PREALLOCATE =      Etw::EVENT_TRACE_FILE_MODE_PREALLOCATE;
+        // EVENT_TRACE_NONSTOPPABLE_MODE
+        // EVENT_TRACE_SECURE_MODE
+        // EVENT_TRACE_REAL_TIME_MODE
+        // On Windows Vista or later, this mode is not applicable should not be used.
+        // EVENT_TRACE_DELAY_OPEN_FILE_MODE
+        // EVENT_TRACE_BUFFERING_MODE
+        // EVENT_TRACE_PRIVATE_LOGGER_MODE
+        /// > Use kilobytes as the unit of measure for specifying the size of a file. The default unit of measure is megabytes. This mode applies to the MaxFileSize registry value for an AutoLogger session and the MaximumFileSize member of EVENT_TRACE_PROPERTIES.
+        const EVENT_TRACE_USE_KBYTES_FOR_SIZE =        Etw::EVENT_TRACE_USE_KBYTES_FOR_SIZE;
+        /// > Uses sequence numbers that are unique across event tracing sessions. This mode only applies to events logged using the TraceMessage function. For more information, see TraceMessage for usage details.<br/>
+        /// > EVENT_TRACE_USE_GLOBAL_SEQUENCE and EVENT_TRACE_USE_LOCAL_SEQUENCE are mutually exclusive.
+        const EVENT_TRACE_USE_GLOBAL_SEQUENCE =        Etw::EVENT_TRACE_USE_GLOBAL_SEQUENCE;
+        /// > Uses sequence numbers that are unique only for an individual event tracing session. This mode only applies to events logged using the TraceMessage function. For more information, see TraceMessage for usage details.<br/>
+        /// > EVENT_TRACE_USE_GLOBAL_SEQUENCE and EVENT_TRACE_USE_LOCAL_SEQUENCE are mutually exclusive.
+        const EVENT_TRACE_USE_LOCAL_SEQUENCE =         Etw::EVENT_TRACE_USE_LOCAL_SEQUENCE;
+        // EVENT_TRACE_PRIVATE_IN_PROC
+        // EVENT_TRACE_MODE_RESERVED
+        // EVENT_TRACE_STOP_ON_HYBRID_SHUTDOWN
+        // EVENT_TRACE_PERSIST_ON_HYBRID_SHUTDOWN
+        // EVENT_TRACE_USE_PAGED_MEMORY
+        // EVENT_TRACE_SYSTEM_LOGGER_MODE
+        // EVENT_TRACE_INDEPENDENT_SESSION_MODE
+        // EVENT_TRACE_NO_PER_PROCESSOR_BUFFERING
+        // EVENT_TRACE_ADDTO_TRIAGE_DUMP
+    }
+}
+
+impl std::default::Default for DumpFileLoggingMode {
+    fn default() -> Self {
+        Self::EVENT_TRACE_FILE_MODE_NONE
+    }
+}
 
 /// Wrapper over an [EVENT_TRACE_PROPERTIES](https://docs.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties), and its allocated companion members
 ///
@@ -118,8 +181,10 @@ bitflags! {
 #[derive(Clone, Copy)]
 pub struct EventTraceProperties {
     etw_trace_properties: Etw::EVENT_TRACE_PROPERTIES,
+    /// The trace name to subscribe to
     wide_trace_name: [u16; TRACE_NAME_MAX_CHARS+1],    // The +1 leaves space for the final null widechar.
-    wide_log_file_name: [u16; TRACE_NAME_MAX_CHARS+1], // The +1 leaves space for the final null widechar. Not used currently, but this may be useful when resolving https://github.com/n4r1b/ferrisetw/issues/7
+    /// The file name (if any) we store our events to
+    wide_etl_dump_file_path: [u16; TRACE_NAME_MAX_CHARS+1], // The +1 leaves space for the final null widechar.
 }
 
 
@@ -136,9 +201,11 @@ impl EventTraceProperties {
     /// Create a new instance
     ///
     /// # Notes
-    /// `trace_name` is limited to 200 characters.
+    /// `trace_name` is limited to 200 characters.<br/>
+    /// The path to the dump file is limited to 200 characters.
     pub(crate) fn new<T>(
         trace_name: &U16CStr,
+        etl_dump_file: Option<(&U16CStr, DumpFileLoggingMode, Option<u32>)>,
         trace_properties: &TraceProperties,
         enable_flags: Etw::EVENT_TRACE_FLAG,
     ) -> Self
@@ -166,22 +233,40 @@ impl EventTraceProperties {
         etw_trace_properties.LogFileMode |= T::augmented_file_mode();
         etw_trace_properties.EnableFlags = enable_flags;
 
-        // etw_trace_properties.LogFileNameOffset must be 0, but this will change when https://github.com/n4r1b/ferrisetw/issues/7 is resolved
-        // > If you do not want to log events to a log file (for example, if you specify EVENT_TRACE_REAL_TIME_MODE only), set LogFileNameOffset to 0.
-        // (https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties)
-        etw_trace_properties.LoggerNameOffset = offset_of!(EventTraceProperties, wide_trace_name) as u32;
+        let mut s = Self {
+            etw_trace_properties,
+            wide_trace_name: [0u16; TRACE_NAME_MAX_CHARS+1],
+            wide_etl_dump_file_path: [0u16; TRACE_NAME_MAX_CHARS+1],
+        };
 
         // https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties#remarks
         // > You do not copy the session name to the offset. The StartTrace function copies the name for you.
         //
         // Let's do it anyway, even though that's not required
-        let mut s = Self {
-            etw_trace_properties,
-            wide_trace_name: [0u16; TRACE_NAME_MAX_CHARS+1],
-            wide_log_file_name: [0u16; TRACE_NAME_MAX_CHARS+1],
-        };
         let name_len = trace_name.len().min(TRACE_NAME_MAX_CHARS);
         s.wide_trace_name[..name_len].copy_from_slice(&trace_name.as_slice()[..name_len]);
+        s.etw_trace_properties.LoggerNameOffset = offset_of!(EventTraceProperties, wide_trace_name) as u32;
+
+        // Also populate the file name, if any
+        match etl_dump_file {
+            None => {
+                // Here, we do not want to dump events to a file
+                // > If you do not want to log events to a log file (for example, if you specify EVENT_TRACE_REAL_TIME_MODE only), set LogFileNameOffset to 0.
+                // (https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties)
+                s.etw_trace_properties.LogFileNameOffset = 0;
+            },
+            Some((path, file_mode, max_size)) => {
+                // Set the file path, and set the dump-file-related flags
+                let path_len = path.len().min(TRACE_NAME_MAX_CHARS);
+                s.wide_etl_dump_file_path[..path_len].copy_from_slice(&path.as_slice()[..path_len]);
+                s.etw_trace_properties.LogFileNameOffset = offset_of!(EventTraceProperties, wide_etl_dump_file_path) as u32;
+
+                s.etw_trace_properties.LogFileMode |= file_mode.bits();
+                if let Some(max_file_size) = max_size {
+                    s.etw_trace_properties.MaximumFileSize = max_file_size;
+                }
+            },
+        }
 
         s
     }

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -154,11 +154,16 @@ fn filter_invalid_control_handle(h: ControlHandle) -> Option<ControlHandle> {
 /// Create a new session.
 ///
 /// This builds an `EventTraceProperties`, calls `StartTraceW` and returns the built `EventTraceProperties` as well as the trace ControlHandle
-pub(crate) fn start_trace<T>(trace_name: &U16CStr, trace_properties: &TraceProperties, enable_flags: Etw::EVENT_TRACE_FLAG) -> EvntraceNativeResult<(EventTraceProperties, ControlHandle)>
+pub(crate) fn start_trace<T>(
+    trace_name: &U16CStr,
+    etl_dump_file: Option<(&U16CStr, DumpFileLoggingMode, Option<u32>)>,
+    trace_properties: &TraceProperties,
+    enable_flags: Etw::EVENT_TRACE_FLAG
+) -> EvntraceNativeResult<(EventTraceProperties, ControlHandle)>
 where
     T: TraceTrait
 {
-    let mut properties = EventTraceProperties::new::<T>(trace_name, trace_properties, enable_flags);
+    let mut properties = EventTraceProperties::new::<T>(trace_name, etl_dump_file, trace_properties, enable_flags);
 
     let mut control_handle = ControlHandle::default();
     let status = unsafe {

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -27,7 +27,7 @@ use super::etw_types::*;
 use crate::provider::Provider;
 use crate::provider::event_filter::EventFilterDescriptor;
 use crate::native::etw_types::event_record::EventRecord;
-use crate::trace::{TraceProperties, TraceTrait};
+use crate::trace::{TraceProperties, RealTimeTraceTrait};
 use crate::trace::callback_data::CallbackData;
 
 
@@ -161,7 +161,7 @@ pub(crate) fn start_trace<T>(
     enable_flags: Etw::EVENT_TRACE_FLAG
 ) -> EvntraceNativeResult<(EventTraceProperties, ControlHandle)>
 where
-    T: TraceTrait
+    T: RealTimeTraceTrait
 {
     let mut properties = EventTraceProperties::new::<T>(trace_name, etl_dump_file, trace_properties, enable_flags);
 

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -10,7 +10,7 @@ use std::ffi::c_void;
 
 use once_cell::sync::Lazy;
 
-use widestring::{U16CString, U16CStr};
+use widestring::U16CStr;
 use windows::Win32::System::Diagnostics::Etw::EVENT_CONTROL_CODE_ENABLE_PROVIDER;
 use windows::core::GUID;
 use windows::core::PCWSTR;
@@ -198,8 +198,8 @@ where
 ///
 /// Microsoft calls this "opening" the trace (and this calls `OpenTraceW`)
 #[allow(clippy::borrowed_box)] // Being Boxed is really important, let's keep the Box<...> in the function signature to make the intent clearer
-pub(crate) fn open_trace(trace_name: U16CString, callback_data: &Box<Arc<CallbackData>>) -> EvntraceNativeResult<TraceHandle> {
-    let mut log_file = EventTraceLogfile::create(callback_data, trace_name, trace_callback_thunk);
+pub(crate) fn open_trace(subscription_source: SubscriptionSource, callback_data: &Box<Arc<CallbackData>>) -> EvntraceNativeResult<TraceHandle> {
+    let mut log_file = EventTraceLogfile::create(callback_data, subscription_source, trace_callback_thunk);
 
     if let Err(ContextError::AlreadyExist) = UNIQUE_VALID_CONTEXTS.insert(log_file.context_ptr()) {
         // That's probably possible to get multiple handles to the same trace, by opening them multiple times.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -28,8 +28,6 @@ impl From<crate::native::PlaError> for ProviderError {
     }
 }
 
-type EtwCallback = Box<dyn FnMut(&EventRecord, &SchemaLocator) + Send + Sync + 'static>;
-
 /// Describes an ETW Provider to use, along with its options
 pub struct Provider {
     /// Provider GUID
@@ -49,7 +47,7 @@ pub struct Provider {
     /// Provider filters
     filters: Vec<EventFilter>,
     /// Callbacks that will receive events from this Provider
-    callbacks: Arc<RwLock<Vec<EtwCallback>>>,
+    callbacks: Arc<RwLock<Vec<crate::EtwCallback>>>,
 }
 
 /// A Builder for a `Provider`
@@ -63,7 +61,7 @@ pub struct ProviderBuilder {
     trace_flags: TraceFlags,
     kernel_flags: u32,
     filters: Vec<EventFilter>,
-    callbacks: Arc<RwLock<Vec<EtwCallback>>>,
+    callbacks: Arc<RwLock<Vec<crate::EtwCallback>>>,
 }
 
 impl std::fmt::Debug for ProviderBuilder {

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -161,7 +161,7 @@ impl TraceTrait for KernelTrace {
 
 
 
-/// A trace session to collect events from user-mode applications
+/// A real-time trace session to collect events from user-mode applications
 ///
 /// To stop the session, you can drop this instance
 #[derive(Debug)]
@@ -176,7 +176,7 @@ pub struct UserTrace {
     callback_data: Box<Arc<CallbackData>>,
 }
 
-/// A trace session to collect events from kernel-mode drivers
+/// A real-time trace session to collect events from kernel-mode drivers
 ///
 /// To stop the session, you can drop this instance
 #[derive(Debug)]
@@ -341,7 +341,9 @@ impl private::PrivateTraceTrait for KernelTrace {
 impl<T: TraceTrait + PrivateTraceTrait> TraceBuilder<T> {
     /// Define the trace name
     ///
-    /// For kernel traces on Windows Versions older than Win8, this method won't change the trace name. In those versions the trace name will be set to "NT Kernel Logger"
+    /// For kernel traces on Windows Versions older than Win8, this method won't change the trace name. In those versions the trace name will be set to "NT Kernel Logger".
+    ///
+    /// Note: this trace name may be truncated to a few hundred characters if it is too long.
     pub fn named(mut self, name: String) -> Self {
         if T::TRACE_KIND == private::TraceKind::Kernel && version_helper::is_win8_or_greater() == false {
             self.name = String::from(KERNEL_LOGGER_NAME);

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -6,6 +6,10 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
+use windows::core::GUID;
+use windows::Win32::System::Diagnostics::Etw;
+use widestring::U16CString;
+
 use self::private::{PrivateRealTimeTraceTrait, PrivateTraceTrait};
 
 use crate::native::etw_types::EventTraceProperties;
@@ -13,9 +17,6 @@ use crate::native::version_helper;
 use crate::native::evntrace::{ControlHandle, TraceHandle, start_trace, open_trace, process_trace, enable_provider, control_trace, control_trace_by_name, close_trace};
 use crate::provider::Provider;
 use crate::utils;
-use windows::core::GUID;
-use windows::Win32::System::Diagnostics::Etw;
-use widestring::U16CString;
 
 pub use crate::native::etw_types::LoggingMode;
 pub use crate::native::etw_types::DumpFileLoggingMode;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -12,7 +12,7 @@ use widestring::U16CString;
 
 use self::private::{PrivateRealTimeTraceTrait, PrivateTraceTrait};
 
-use crate::native::etw_types::EventTraceProperties;
+use crate::native::etw_types::{EventTraceProperties, SubscriptionSource};
 use crate::native::version_helper;
 use crate::native::evntrace::{ControlHandle, TraceHandle, start_trace, open_trace, process_trace, enable_provider, control_trace, control_trace_by_name, close_trace};
 use crate::provider::Provider;
@@ -453,7 +453,7 @@ impl<T: RealTimeTraceTrait + PrivateRealTimeTraceTrait> TraceBuilder<T> {
             }
         }
 
-        let trace_handle = open_trace(trace_wide_name, &callback_data)?;
+        let trace_handle = open_trace(SubscriptionSource::RealTimeSession(trace_wide_name), &callback_data)?;
 
         Ok((T::build(
                 full_properties,

--- a/src/trace/callback_data.rs
+++ b/src/trace/callback_data.rs
@@ -1,10 +1,10 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::trace::{TraceTrait, RealTimeTraceTrait};
+use windows::Win32::System::Diagnostics::Etw;
+
 use crate::native::etw_types::event_record::EventRecord;
 use crate::provider::Provider;
 use crate::schema_locator::SchemaLocator;
-use windows::Win32::System::Diagnostics::Etw;
 
 pub use crate::native::etw_types::LoggingMode;
 

--- a/src/trace/callback_data.rs
+++ b/src/trace/callback_data.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use crate::trace::TraceTrait;
+use crate::trace::{TraceTrait, RealTimeTraceTrait};
 use crate::native::etw_types::event_record::EventRecord;
 use crate::provider::Provider;
 use crate::schema_locator::SchemaLocator;
@@ -42,7 +42,7 @@ impl CallbackData {
         self.events_handled.load(Ordering::Relaxed)
     }
 
-    pub fn provider_flags<T: TraceTrait>(&self) -> Etw::EVENT_TRACE_FLAG {
+    pub fn provider_flags<T: RealTimeTraceTrait>(&self) -> Etw::EVENT_TRACE_FLAG {
         Etw::EVENT_TRACE_FLAG(T::enable_flags(&self.providers))
     }
 

--- a/src/trace/callback_data.rs
+++ b/src/trace/callback_data.rs
@@ -1,31 +1,64 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::RwLock;
 
 use windows::Win32::System::Diagnostics::Etw;
 
+use crate::trace::RealTimeTraceTrait;
 use crate::native::etw_types::event_record::EventRecord;
 use crate::provider::Provider;
 use crate::schema_locator::SchemaLocator;
+use crate::EtwCallback;
 
 pub use crate::native::etw_types::LoggingMode;
 
 /// Data used by callbacks when the trace is running
 // NOTE: this structure is accessed in an unsafe block in a separate thread (see the `trace_callback_thunk` function)
 //       Thus, this struct must not be mutated (outside of interior mutability and/or using Mutex and other synchronization mechanisms) when the associated trace is running.
-#[derive(Debug, Default)]
-pub struct CallbackData {
+#[derive(Debug)]
+pub enum CallbackData {
+    RealTime(RealTimeCallbackData),
+    FromFile(CallbackDataFromFile),
+}
+
+#[derive(Debug)]
+pub struct RealTimeCallbackData {
     /// Represents how many events have been handled so far
     events_handled: AtomicUsize,
+    schema_locator: SchemaLocator,
     /// List of Providers associated with the Trace. This also owns the callback closures and their state
     providers: Vec<Provider>,
+}
+
+pub struct CallbackDataFromFile {
+    /// Represents how many events have been handled so far
+    events_handled: AtomicUsize,
     schema_locator: SchemaLocator,
+    /// This trace is reading from an ETL file, and has a single callback
+    callback: RwLock<EtwCallback>,
 }
 
 impl CallbackData {
+    pub fn on_event(&self, record: &EventRecord) {
+        match self {
+            CallbackData::RealTime(rt_cb) => rt_cb.on_event(record),
+            CallbackData::FromFile(f_cb) => f_cb.on_event(record),
+        }
+    }
+
+    pub fn events_handled(&self) -> usize {
+        match self {
+            CallbackData::RealTime(rt_cb) => rt_cb.events_handled(),
+            CallbackData::FromFile(f_cb) => f_cb.events_handled(),
+        }
+    }
+}
+
+impl RealTimeCallbackData {
     pub fn new() -> Self {
         Self {
             events_handled: AtomicUsize::new(0),
-            providers: Vec::new(),
             schema_locator: SchemaLocator::new(),
+            providers: Vec::new(),
         }
     }
 
@@ -49,12 +82,42 @@ impl CallbackData {
     pub fn on_event(&self, record: &EventRecord) {
         self.events_handled.fetch_add(1, Ordering::Relaxed);
 
-        // We need a mutable reference to be able to modify the data it refers, which is actually
-        // done within the Callback (The schema locator is modified)
         for prov in &self.providers {
             if prov.guid() == record.provider_id() {
                 prov.on_event(record, &self.schema_locator);
             }
         }
+    }
+}
+
+
+impl CallbackDataFromFile {
+    pub fn new(callback: EtwCallback) -> Self {
+        Self {
+            events_handled: AtomicUsize::new(0),
+            schema_locator: SchemaLocator::new(),
+            callback: RwLock::new(callback),
+        }
+    }
+
+    /// How many events have been handled since this instance was created
+    pub fn events_handled(&self) -> usize {
+        self.events_handled.load(Ordering::Relaxed)
+    }
+
+    pub fn on_event(&self, record: &EventRecord) {
+        self.events_handled.fetch_add(1, Ordering::Relaxed);
+        if let Ok(mut cb) = self.callback.write() {
+            cb(record, &self.schema_locator);
+        }
+    }
+}
+
+impl std::fmt::Debug for CallbackDataFromFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CallbackDataFromFile")
+            .field("events_handled", &self.events_handled)
+            .field("schema_locator", &self.schema_locator)
+            .finish()
     }
 }

--- a/tests/file_trace.rs
+++ b/tests/file_trace.rs
@@ -1,0 +1,58 @@
+use std::time::Duration;
+use std::path::PathBuf;
+
+use ferrisetw::EventRecord;
+use ferrisetw::{UserTrace, FileTrace};
+use ferrisetw::provider::Provider;
+use ferrisetw::schema_locator::SchemaLocator;
+use ferrisetw::trace::DumpFileParams;
+use ferrisetw::trace::TraceTrait;
+
+#[test]
+fn etl_file() {
+    env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
+
+    let dump_file = DumpFileParams{
+        file_path: PathBuf::from("etw-dump-file.etl"),
+        ..Default::default()
+    };
+    let events_processes = save_a_trace(dump_file.clone());
+    let events_read = process_from_file(dump_file.file_path);
+
+    assert!(events_processes > 0); // otherwise this test will not test much
+    assert!(events_read > events_processes); // The ETW framework can insert synthetic events, e.g. to give info about the current trace status. So, there may not be a perfec equality here
+}
+
+fn empty_callback(_record: &EventRecord, _schema_locator: &SchemaLocator) {}
+
+fn save_a_trace(dump_file: DumpFileParams) -> usize {
+    let process_provider = Provider
+        ::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
+        .add_callback(empty_callback)
+        .build();
+
+    let trace = UserTrace::new()
+        .named(String::from("MyTrace"))
+        .enable(process_provider)
+        .set_etl_dump_file(dump_file)
+        .start_and_process()
+        .unwrap();
+
+    std::thread::sleep(Duration::from_secs(10));
+
+    let n_events = trace.events_handled();
+    println!("Processed {} events", n_events);
+    n_events
+}
+
+fn process_from_file(input_file: PathBuf) -> usize {
+    let (trace, handle) = FileTrace::new(input_file, empty_callback)
+        .start()
+        .unwrap();
+
+    FileTrace::process_from_handle(handle).unwrap();
+
+    let n_events = trace.events_handled();
+    println!("Read {} events from file", n_events);
+    n_events
+}

--- a/tests/trace_lifetime.rs
+++ b/tests/trace_lifetime.rs
@@ -7,6 +7,7 @@ use ferrisetw::EventRecord;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::UserTrace;
 use ferrisetw::trace::TraceTrait;
+use ferrisetw::trace::RealTimeTraceTrait;
 
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Closes #7 

This PR makes it possible to dump a real-time session into a `.etl` file, or to start a trace that processes events from a `.etl` file.

As discussed in #7, I still feel there is too much coupling between our `ferrisetw::Provider` and their callbacks. That makes it not so trivial to add callbacks for a file trace (that has no "providers" in the ETW sense). 
I finally turned `CallbackData` into an enum. This solution isn't perfect, but that is not-so-hacky, so I think this will do.

If you agree to merge this, you may also want to release a 1.1 version with this new feature.