### PR TITLE
Serialize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/n4r1b/ferrisetw"
 [features]
 # Enable the conversion of timestamps to time::OffsetDateTime
 time_rs = ["time"]
+serde = [ "dep:serde", "time?/serde", "time?/serde-human-readable" ]
 
 [dependencies]
 windows = { version = "0.48", features = [
@@ -37,9 +38,12 @@ bitflags = "1.3.2"
 widestring = "1.0"
 zerocopy = "0.6"
 time = { version = "0.3", features = ["large-dates"], optional = true }
+serde = { version = "1.0", optional = true }
 # thiserror = "~1.0"
 # anyhow = "~1.0"
 log = "0.4"
 
 [dev-dependencies]
 env_logger = "0.10" # used in examples
+serde_json = "1.0"
+flexbuffers = "2.0"

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -25,7 +25,6 @@ fn dns_etw_callback(
                 "Unable to get the ETW schema for a DNS event: {:?}",
                 err
             );
-            return;
         },
 
         Ok(schema) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ pub mod schema_locator;
 pub mod trace;
 mod traits;
 mod utils;
+pub mod ser;
 
 pub(crate) type EtwCallback = Box<dyn FnMut(&EventRecord, &SchemaLocator) + Send + Sync + 'static>;
 
@@ -132,6 +133,8 @@ pub use crate::trace::KernelTrace;
 pub use crate::trace::FileTrace;
 pub use crate::native::etw_types::event_record::EventRecord;
 pub use crate::schema_locator::SchemaLocator;
+#[cfg(feature = "serde")]
+pub use crate::ser::{EventSerializer, EventSerializerOptions};
 
 // These types are returned by some public APIs of this crate.
 // They must be re-exported, so that users of the crate have a way to avoid version conflicts

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -232,7 +232,7 @@ impl EventTraceProperties {
         etw_trace_properties.MaximumBuffers = trace_properties.max_buffer;
         etw_trace_properties.FlushTimer = trace_properties.flush_timer.as_secs().clamp(1, u32::MAX as u64) as u32; // See https://learn.microsoft.com/en-us/windows/win32/api/evntrace/ns-evntrace-event_trace_properties
 
-        if trace_properties.log_file_mode.is_empty() == false {
+        if !trace_properties.log_file_mode.is_empty() {
             etw_trace_properties.LogFileMode = trace_properties.log_file_mode.bits();
         } else {
             etw_trace_properties.LogFileMode =

--- a/src/native/etw_types/event_record.rs
+++ b/src/native/etw_types/event_record.rs
@@ -5,6 +5,8 @@ use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
 
 use crate::native::etw_types::extended_data::EventHeaderExtendedDataItem;
 
+use super::EVENT_HEADER_FLAG_32_BIT_HEADER;
+
 /// A read-only wrapper over an [EVENT_RECORD](https://docs.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_record)
 #[repr(transparent)]
 pub struct EventRecord(pub(crate) EVENT_RECORD);
@@ -109,6 +111,14 @@ impl EventRecord {
                 self.0.UserData as *mut _,
                 self.0.UserDataLength.into(),
             )
+        }
+    }
+    
+    pub(crate) fn pointer_size(&self) -> usize {
+        if self.event_flags() & EVENT_HEADER_FLAG_32_BIT_HEADER != 0 {
+            4
+        } else {
+            8
         }
     }
 

--- a/src/native/etw_types/event_record.rs
+++ b/src/native/etw_types/event_record.rs
@@ -1,13 +1,13 @@
 //! Safe wrappers over the EVENT_RECORD type
 
-use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
 use windows::core::GUID;
+use windows::Win32::System::Diagnostics::Etw::EVENT_RECORD;
 
 use crate::native::etw_types::extended_data::EventHeaderExtendedDataItem;
 
 /// A read-only wrapper over an [EVENT_RECORD](https://docs.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_record)
 #[repr(transparent)]
-pub struct EventRecord(EVENT_RECORD);
+pub struct EventRecord(pub(crate) EVENT_RECORD);
 
 impl EventRecord {
     /// Create a `&self` from a Windows pointer.
@@ -100,21 +100,7 @@ impl EventRecord {
     /// The `TimeStamp` field from the wrapped `EVENT_RECORD`, as a strongly-typed `time::OffsetDateTime`
     #[cfg(feature = "time_rs")]
     pub fn timestamp(&self) -> time::OffsetDateTime {
-        // "system time" means the count of hundreds of nanoseconds since midnight, January 1, 1601
-        let system_time = self.0.EventHeader.TimeStamp;
-
-        const SECONDS_BETWEEN_1601_AND_1970: i128 = 11_644_473_600;
-        const HUNDREDS_OF_NANOS_IN_SECOND: i128 = 10_000_000;
-        const HUNDREDS_OF_NANOSECONDS_BETWEEN_1601_AND_1970: i128 =
-            SECONDS_BETWEEN_1601_AND_1970 * HUNDREDS_OF_NANOS_IN_SECOND;
-
-        let unix_as_hundreds_of_nano_seconds = (system_time as i128) - HUNDREDS_OF_NANOSECONDS_BETWEEN_1601_AND_1970;
-        let unix_as_nano_seconds = unix_as_hundreds_of_nano_seconds * 100;
-
-        // Can't panic.
-        // A filetime can go from 1601 to 30828.
-        // OffsetDateTime (with the 'large-dates' feature) can represent any time from year -999_999 to +999_999. Meanwhile, .
-        time::OffsetDateTime::from_unix_timestamp_nanos(unix_as_nano_seconds).unwrap()
+        crate::native::time::FileTime::from_quad(self.0.EventHeader.TimeStamp).into()
     }
 
     pub(crate) fn user_buffer(&self) -> &[u8] {

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -99,7 +99,7 @@ extern "system" fn trace_callback_thunk(p_record: *mut Etw::EVENT_RECORD) {
 
         if let Some(event_record) = record_from_ptr {
             let p_user_context = event_record.user_context();
-            if UNIQUE_VALID_CONTEXTS.is_valid(p_user_context) == false {
+            if !UNIQUE_VALID_CONTEXTS.is_valid(p_user_context) {
                 return;
             }
             let p_callback_data = p_user_context.cast::<Arc<CallbackData>>();

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod sddl;
 pub(crate) mod tdh;
 pub(crate) mod tdh_types;
 pub(crate) mod version_helper;
+pub mod time;
 
 // These are used in our custom error types, and must be part of the public API
 pub use pla::PlaError;

--- a/src/native/tdh.rs
+++ b/src/native/tdh.rs
@@ -27,6 +27,15 @@ pub enum TdhNativeError {
 
 pub type TdhNativeResult<T> = Result<T, TdhNativeError>;
 
+impl std::fmt::Display for TdhNativeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AllocationError => write!(f, "allocation error"),
+            Self::IoError(e) => write!(f, "i/o error {}", e),
+        }
+    }
+}
+
 
 /// Read-only wrapper over an [TRACE_EVENT_INFO]
 ///

--- a/src/native/tdh_types.rs
+++ b/src/native/tdh_types.rs
@@ -13,13 +13,20 @@ use num_traits::FromPrimitive;
 
 use windows::Win32::System::Diagnostics::Etw;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PropertyError{
     /// Parsing complex types in properties is not supported in this crate
     /// (yet? See <https://github.com/n4r1b/ferrisetw/issues/76>)
     UnimplementedType
 }
 
+impl std::fmt::Display for PropertyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnimplementedType => write!(f, "unimplemented type"),
+        }
+    }
+}
 
 /// Attributes of a property
 #[derive(Debug, Clone, Default)]

--- a/src/native/tdh_types.rs
+++ b/src/native/tdh_types.rs
@@ -40,7 +40,7 @@ impl Property {
     pub fn new(name: String, property: &Etw::EVENT_PROPERTY_INFO) -> Result<Self, PropertyError> {
         let flags = PropertyFlags::from(property.Flags);
 
-        if flags.contains(PropertyFlags::PROPERTY_STRUCT) == false {
+        if !flags.contains(PropertyFlags::PROPERTY_STRUCT) {
             // The property is a non-struct type. It makes sense to access these fields of the unions
             let ot = unsafe { property.Anonymous1.nonStructType.OutType };
             let it = unsafe { property.Anonymous1.nonStructType.InType };
@@ -86,9 +86,10 @@ impl Property {
 
 /// Represent a TDH_IN_TYPE
 #[repr(u16)]
-#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq, Eq, Default)]
 pub enum TdhInType {
     // Deprecated values are not defined
+    #[default]
     InTypeNull,
     InTypeUnicodeString,
     InTypeAnsiString,
@@ -114,16 +115,11 @@ pub enum TdhInType {
     InTypeCountedString = 300,
 }
 
-impl Default for TdhInType {
-    fn default() -> TdhInType {
-        TdhInType::InTypeNull
-    }
-}
-
 /// Represent a TDH_OUT_TYPE
 #[repr(u16)]
-#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, FromPrimitive, ToPrimitive, PartialEq, Eq, Default)]
 pub enum TdhOutType {
+    #[default]
     OutTypeNull,
     OutTypeString,
     OutTypeDateTime,
@@ -157,12 +153,6 @@ pub enum TdhOutType {
     OutTypePkcs7 = 36,
     OutTypeCodePointer = 37,
     OutTypeDatetimeUtc = 38,
-}
-
-impl Default for TdhOutType {
-    fn default() -> TdhOutType {
-        TdhOutType::OutTypeNull
-    }
 }
 
 bitflags! {

--- a/src/native/tdh_types.rs
+++ b/src/native/tdh_types.rs
@@ -29,10 +29,10 @@ pub struct Property {
     /// Represent the [PropertyFlags]
     pub flags: PropertyFlags,
     /// TDH In type of the property
-    length: u16,
-    in_type: TdhInType,
+    pub length: u16,
+    pub in_type: TdhInType,
     /// TDH Out type of the property
-    out_type: TdhOutType,
+    pub out_type: TdhOutType,
 }
 
 #[doc(hidden)]

--- a/src/native/time.rs
+++ b/src/native/time.rs
@@ -1,0 +1,167 @@
+///! Implements wrappers for various Windows time structures.
+use windows::Win32::{
+    Foundation::{FILETIME, SYSTEMTIME},
+    System::Time::SystemTimeToFileTime,
+};
+
+/// Wrapper for [FILETIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime)
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct FileTime(pub(crate) FILETIME);
+
+impl std::default::Default for FileTime {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+const SECONDS_BETWEEN_1601_AND_1970: i64 = 11_644_473_600;
+const NS_IN_SECOND: i64 = 1_000_000_000;
+const MS_IN_SECOND: i64 = 1_000;
+
+impl FileTime {
+    /// Converts to a unix timestamp with millisecond granularity.
+    pub fn as_unix_timestamp(&self) -> i64 {
+        self.as_quad() / 10_000 - (SECONDS_BETWEEN_1601_AND_1970 * MS_IN_SECOND) 
+    }
+
+    /// Converts to a unix timestamp with nanosecond granularity.
+    pub fn as_unix_timestamp_nanos(&self) -> i128 {
+        self.as_quad() as i128 * 100 - (SECONDS_BETWEEN_1601_AND_1970 as i128 * NS_IN_SECOND as i128)
+    }
+    
+    /// Converts to OffsetDateTime
+    #[cfg(feature = "time_rs")]
+    pub fn as_date_time(&self) -> time::OffsetDateTime {
+        time::OffsetDateTime::from_unix_timestamp_nanos(self.as_unix_timestamp_nanos()).unwrap()
+    }
+    
+    fn as_quad(&self) -> i64 {
+        let mut quad = self.0.dwHighDateTime as i64;
+        quad <<= 32;
+        quad |= self.0.dwHighDateTime as i64;
+        quad
+    }
+
+    #[cfg(any(feature = "time_rs", feature = "serde"))]
+    pub(crate) fn from_quad(quad: i64) -> Self {
+        let mut file_time: FileTime = Default::default();
+        file_time.0.dwHighDateTime = (quad >> 32) as u32;
+        file_time.0.dwLowDateTime = (quad & 0xffffffff) as u32;
+        file_time
+    }
+
+    pub(crate) fn from_slice(slice: &[u8; std::mem::size_of::<FileTime>()]) -> Self {
+        let ptr = slice.as_ptr() as *const FileTime;
+        let mut file_time: FileTime = Default::default();
+        unsafe {
+            file_time.0.dwHighDateTime = (*ptr).0.dwHighDateTime;
+            file_time.0.dwLowDateTime = (*ptr).0.dwLowDateTime;
+        }
+        file_time
+    }
+}
+
+#[cfg(feature = "time_rs")]
+impl Into<time::OffsetDateTime> for FileTime {
+    fn into(self) -> time::OffsetDateTime {
+        self.as_date_time()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::ser::Serialize for FileTime {
+    #[cfg(feature = "time_rs")]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_date_time().serialize(serializer)
+    }
+
+    #[cfg(not(feature = "time_rs"))]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_unix_timestamp().serialize(serializer)
+    }
+}
+
+/// Wrapper for [SYSTEMTIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime)
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct SystemTime(pub(crate) SYSTEMTIME);
+
+impl std::default::Default for SystemTime {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl SystemTime {
+    /// Converts to a unix timestamp with millisecond granularity.
+    pub fn as_unix_timestamp(&self) -> i64 {
+        let file_time: FileTime = Default::default();
+        unsafe {
+            _ = SystemTimeToFileTime(&self.0 as *const _, &file_time.0 as *const _ as *mut _);
+        }
+        file_time.as_unix_timestamp()
+    }
+
+    /// Converts to a unix timestamp with nanosecond granularity.
+    pub fn as_unix_timestamp_nanos(&self) -> i128 {
+        let file_time: FileTime = Default::default();
+        unsafe {
+            _ = SystemTimeToFileTime(&self.0 as *const _, &file_time.0 as *const _ as *mut _);
+        }
+        file_time.as_unix_timestamp_nanos()
+    }
+
+    /// Converts to OffsetDateTime
+    #[cfg(feature = "time_rs")]
+    pub fn as_date_time(&self) -> time::OffsetDateTime {
+        time::OffsetDateTime::from_unix_timestamp_nanos(self.as_unix_timestamp_nanos()).unwrap()
+    }
+
+    pub(crate) fn from_slice(slice: &[u8; std::mem::size_of::<SystemTime>()]) -> Self {
+        let ptr = slice.as_ptr() as *const SystemTime;
+        let mut system_time: SystemTime = Default::default();
+        unsafe {
+            system_time.0.wYear = (*ptr).0.wYear;
+            system_time.0.wMonth = (*ptr).0.wMonth;
+            system_time.0.wDayOfWeek = (*ptr).0.wDayOfWeek;
+            system_time.0.wDay = (*ptr).0.wDay;
+            system_time.0.wHour = (*ptr).0.wHour;
+            system_time.0.wMinute = (*ptr).0.wMinute;
+            system_time.0.wMilliseconds = (*ptr).0.wMilliseconds;
+        }
+        system_time
+    }
+}
+
+#[cfg(feature = "time_rs")]
+impl Into<time::OffsetDateTime> for SystemTime {
+    fn into(self) -> time::OffsetDateTime {
+        self.as_date_time()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::ser::Serialize for SystemTime {
+    #[cfg(feature = "time_rs")]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_date_time().serialize(serializer)
+    }
+
+    #[cfg(not(feature = "time_rs"))]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_unix_timestamp().serialize(serializer)
+    }
+}

--- a/src/native/time.rs
+++ b/src/native/time.rs
@@ -5,15 +5,9 @@ use windows::Win32::{
 };
 
 /// Wrapper for [FILETIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime)
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 #[repr(transparent)]
 pub struct FileTime(pub(crate) FILETIME);
-
-impl std::default::Default for FileTime {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
 
 const SECONDS_BETWEEN_1601_AND_1970: i64 = 11_644_473_600;
 const NS_IN_SECOND: i64 = 1_000_000_000;
@@ -63,9 +57,9 @@ impl FileTime {
 }
 
 #[cfg(feature = "time_rs")]
-impl Into<time::OffsetDateTime> for FileTime {
-    fn into(self) -> time::OffsetDateTime {
-        self.as_date_time()
+impl From<FileTime> for time::OffsetDateTime {
+    fn from(file_time: FileTime) -> Self {
+        file_time.as_date_time()
     }
 }
 
@@ -89,15 +83,9 @@ impl serde::ser::Serialize for FileTime {
 }
 
 /// Wrapper for [SYSTEMTIME](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime)
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 #[repr(transparent)]
 pub struct SystemTime(pub(crate) SYSTEMTIME);
-
-impl std::default::Default for SystemTime {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
 
 impl SystemTime {
     /// Converts to a unix timestamp with millisecond granularity.
@@ -141,9 +129,9 @@ impl SystemTime {
 }
 
 #[cfg(feature = "time_rs")]
-impl Into<time::OffsetDateTime> for SystemTime {
-    fn into(self) -> time::OffsetDateTime {
-        self.as_date_time()
+impl From<SystemTime> for time::OffsetDateTime {
+    fn from(file_time: SystemTime) -> Self {
+        file_time.as_date_time()
     }
 }
 

--- a/src/native/version_helper.rs
+++ b/src/native/version_helper.rs
@@ -93,7 +93,7 @@ mod test {
     // Let's assume this test won't be run on a version of Windows older than XP :D
     fn test_verify_system_version() {
         match verify_system_version(5, 1, 0) {
-            Ok(res) => assert_eq!(true, res),
+            Ok(res) => assert!(res),
             Err(err) => panic!("VersionHelper error: {:?}", err),
         };
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -447,12 +447,18 @@ impl private::TryParse<String> for Parser<'_, '_> {
                         ));
                     }
 
-                    let wide = unsafe {
+                    let mut wide = unsafe {
                         std::slice::from_raw_parts(
                             prop_slice.buffer.as_ptr() as *const u16,
                             prop_slice.buffer.len() / 2,
                         )
                     };
+
+                    match wide.last() {
+                        // remove the null terminator from the slice
+                        Some(c) if c == &0 => wide = &wide[..wide.len() - 1],
+                        _ => (),
+                    }
 
                     Ok(widestring::decode_utf16_lossy(wide.iter().copied()).collect::<String>())
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,16 +2,15 @@
 //!
 //! This module act as a helper to parse the Buffer from an ETW Event
 
-
-use crate::native::etw_types::EVENT_HEADER_FLAG_32_BIT_HEADER;
 use crate::native::etw_types::event_record::EventRecord;
 use crate::native::sddl;
 use crate::native::tdh;
-use crate::native::tdh_types::PropertyLength;
-use crate::native::tdh_types::{Property, PropertyFlags, TdhInType, TdhOutType};
+use crate::native::tdh_types::{
+    Property, PropertyCount, PropertyInfo, PropertyLength, TdhInType, TdhOutType,
+};
+use crate::native::time::{FileTime, SystemTime};
 use crate::property::PropertySlice;
 use crate::schema::Schema;
-use crate::native::time::{SystemTime, FileTime};
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -25,8 +24,6 @@ pub enum ParserError {
     NotFound,
     /// An invalid type
     InvalidType,
-    /// Some properties are not supported by this crate (yet?)
-    UnsupportedProperties,
     /// Error parsing
     ParseError,
     /// Length mismatch when parsing a type
@@ -71,7 +68,6 @@ impl std::fmt::Display for ParserError {
         match self {
             Self::NotFound => write!(f, "not found"),
             Self::InvalidType => write!(f, "invalid type"),
-            Self::UnsupportedProperties => write!(f, "unsupported properties"),
             Self::ParseError => write!(f, "parse error"),
             Self::LengthMismatch => write!(f, "length mismatch"),
             Self::PropertyError(s) => write!(f, "property error {}", s),
@@ -84,7 +80,6 @@ impl std::fmt::Display for ParserError {
 }
 
 type ParserResult<T> = Result<T, ParserError>;
-
 
 #[derive(Default)]
 /// Cache of the properties we've extracted already
@@ -148,83 +143,116 @@ impl<'schema, 'record> Parser<'schema, 'record> {
         Parser {
             record: event_record,
             properties: schema.properties(),
-            cache: Mutex::new(CachedSlices::default())
+            cache: Mutex::new(CachedSlices::default()),
         }
     }
 
     #[allow(clippy::len_zero)]
-    fn find_property_size(&self, property: &Property, remaining_user_buffer: &[u8]) -> ParserResult<usize> {
-        // There are several cases
-        //  * regular case, where property.len() directly makes sense
-        //  * but EVENT_PROPERTY_INFO.length is an union, and (in its lengthPropertyIndex form) can refeer to another field
-        //    e.g.: the WinInet provider manifest has fields such as `<data name="Verb" inType="win:AnsiString" length="_VerbLength"/>`
-        //    In this case, we defer to TDH to know the right length.
-        
-        // For pointer input type we can immediately infer the size based on the header flags. 
-        if property.in_type == TdhInType::InTypePointer {
-            if self.record.event_flags() & EVENT_HEADER_FLAG_32_BIT_HEADER != 0 {
-                return Ok(4);
-            } else {
-                return Ok(8);
-            }
-        }
-        
-        let prop_len = match property.length {
-            PropertyLength::Length(l) => l,
-            PropertyLength::Index(_) => {
-                // TODO optimize to cache the lookup, the problem is here this is called under an
-                // exclusive mutex, so attempting to extract and cache a related property will
-                // deadlock.
-                return Ok(tdh::property_size(self.record, &property.name)? as usize)
-            }
-        };
-        
-        if prop_len > 0 {
-            return Ok(prop_len as usize);
-        }
+    fn find_property_size(
+        &self,
+        property: &Property,
+        remaining_user_buffer: &[u8],
+    ) -> ParserResult<usize> {
+        match property.info {
+            PropertyInfo::Value {
+                in_type, length, ..
+            } => {
+                // There are several cases
+                //  * regular case, where property.len() directly makes sense
+                //  * but EVENT_PROPERTY_INFO.length is an union, and (in its lengthPropertyIndex form) can refeer to another field
+                //    e.g.: the WinInet provider manifest has fields such as `<data name="Verb" inType="win:AnsiString" length="_VerbLength"/>`
+                //    In this case, we defer to TDH to know the right length.
 
-        // Length is not set. We'll have to ask TDH for the right length.
-        // However, before doing so, there are some cases where we could determine ourselves.
-        // The following _very_ common property types can be short-circuited to prevent the expensive call.
-        // (that's taken from krabsetw)
-
-        if property.flags.is_empty() 
-        && !property.flags.contains(PropertyFlags::PROPERTY_STRUCT) 
-        && property.out_type == TdhOutType::OutTypeString {
-            // Strings that appear at the end of a record may not be null-terminated.
-            // If a string is null-terminated, propertyLength includes the null character.
-            // If a string is not-null terminated, propertyLength includes all bytes up
-            // to the end of the record buffer.
-            match property.in_type {
-                TdhInType::InTypeAnsiString => {
-                    let mut l = 0;
-                    for char in remaining_user_buffer {
-                        if char == &0 {
-                            l += 1; // include the final null byte
-                            break;
-                        }
-                        l += 1;
-                    }
-                    return Ok(l)
-                },
-
-                TdhInType::InTypeUnicodeString => {
-                    let mut l = 0;
-                    for bytes in remaining_user_buffer.chunks_exact(2) {
-                        if bytes[0] == 0 && bytes[1] == 0 {
-                            l += 2;
-                            break;
-                        }
-                        l += 2;
-                    }
-                    return Ok(l);
+                // For pointer input type we can immediately infer the size based on the header flags.
+                if in_type == TdhInType::InTypePointer {
+                    return Ok(self.record.pointer_size());
                 }
 
-                _ => (),
+                let prop_len = match length {
+                    PropertyLength::Length(l) => l,
+                    PropertyLength::Index(_) => {
+                        // TODO optimize to cache the lookup, the problem is here this is called under an
+                        // exclusive mutex, so attempting to extract and cache a related property will
+                        // deadlock.
+                        return Ok(tdh::property_size(self.record, &property.name)? as usize);
+                    }
+                };
+
+                if prop_len > 0 {
+                    return Ok(prop_len as usize);
+                }
+
+                // Length is not set. We'll have to ask TDH for the right length.
+                // However, before doing so, there are some cases where we could determine ourselves.
+                // The following _very_ common property types can be short-circuited to prevent the expensive call.
+                // (that's taken from krabsetw)
+
+                match in_type {
+                    TdhInType::InTypeAnsiString => {
+                        let mut l = 0;
+                        for char in remaining_user_buffer {
+                            if char == &0 {
+                                l += 1; // include the final null byte
+                                break;
+                            }
+                            l += 1;
+                        }
+                        return Ok(l);
+                    }
+                    TdhInType::InTypeUnicodeString => {
+                        let mut l = 0;
+                        for bytes in remaining_user_buffer.chunks_exact(2) {
+                            if bytes[0] == 0 && bytes[1] == 0 {
+                                l += 2;
+                                break;
+                            }
+                            l += 2;
+                        }
+                        return Ok(l);
+                    }
+                    _ => (),
+                }
+
+                Ok(tdh::property_size(self.record, &property.name)? as usize)
+            }
+            PropertyInfo::Array {
+                in_type,
+                length,
+                count,
+                ..
+            } => {
+                // For pointer input type we can immediately infer the size based on the header flags.
+                let prop_len = if in_type == TdhInType::InTypePointer {
+                    self.record.pointer_size()
+                } else {
+                    match length {
+                        PropertyLength::Length(l) => l as usize,
+                        PropertyLength::Index(_) => {
+                            // TODO optimize to cache the lookup, the problem is here this is called under an
+                            // exclusive mutex, so attempting to extract and cache a related property will
+                            // deadlock.
+                            return Ok(tdh::property_size(self.record, &property.name)? as usize);
+                        }
+                    }
+                };
+
+                let prop_count = match count {
+                    PropertyCount::Count(c) => c as usize,
+                    PropertyCount::Index(_) => {
+                        // TODO optimize to cache the lookup, the problem is here this is called under an
+                        // exclusive mutex, so attempting to extract and cache a related property will
+                        // deadlock.
+                        return Ok(tdh::property_size(self.record, &property.name)? as usize);
+                    }
+                };
+
+                if prop_len > 0 {
+                    return Ok(prop_len * prop_count);
+                }
+
+                Ok(tdh::property_size(self.record, &property.name)? as usize)
             }
         }
-
-        Ok(tdh::property_size(self.record, &property.name)? as usize)
     }
 
     fn find_property(&self, name: &str) -> ParserResult<PropertySlice<'schema, 'record>> {
@@ -239,26 +267,37 @@ impl<'schema, 'record> Parser<'schema, 'record> {
         let properties_not_parsed_yet = match self.properties.get(last_cached_property..) {
             Some(s) => s,
             // If we've parsed every property already, that means no property matches this name
-            None => return Err(ParserError::NotFound)
+            None => return Err(ParserError::NotFound),
         };
 
         for property in properties_not_parsed_yet {
-            let remaining_user_buffer = match self.record.user_buffer().get(cache.last_cached_offset..) {
-                None => return Err(ParserError::PropertyError("Invalid buffer bounds".to_owned())),
-                Some(s) => s,
-            };
+            let remaining_user_buffer =
+                match self.record.user_buffer().get(cache.last_cached_offset..) {
+                    None => {
+                        return Err(ParserError::PropertyError(
+                            "Invalid buffer bounds".to_owned(),
+                        ))
+                    }
+                    Some(s) => s,
+                };
 
             let prop_size = self.find_property_size(property, remaining_user_buffer)?;
             let property_buffer = match remaining_user_buffer.get(..prop_size) {
-                None => return Err(ParserError::PropertyError("Property length out of buffer bounds".to_owned())),
+                None => {
+                    return Err(ParserError::PropertyError(
+                        "Property length out of buffer bounds".to_owned(),
+                    ))
+                }
                 Some(s) => s,
             };
 
             let prop_slice = PropertySlice {
                 property,
-                buffer: property_buffer
+                buffer: property_buffer,
             };
-            cache.slices.insert(String::clone(&property.name), prop_slice);
+            cache
+                .slices
+                .insert(String::clone(&property.name), prop_slice);
             cache.last_cached_offset += prop_size;
 
             if property.name == name {
@@ -274,14 +313,13 @@ impl<'schema, 'record> Parser<'schema, 'record> {
     /// You must explicitly define `T`, the type you want to parse the property into.<br/>
     /// In case this type is not compatible with the ETW type, [`ParserError::InvalidType`] is returned.
     pub fn try_parse<T>(&self, name: &str) -> ParserResult<T>
-    where Parser<'schema, 'record>: private::TryParse<T>
+    where
+        Parser<'schema, 'record>: private::TryParse<T>,
     {
         use crate::parser::private::TryParse;
         self.try_parse_impl(name)
     }
 }
-
-
 
 mod private {
     use super::*;
@@ -309,11 +347,45 @@ macro_rules! impl_try_parse_primitive {
             fn try_parse_impl(&self, name: &str) -> ParserResult<$T> {
                 let prop_slice = self.find_property(name)?;
 
-                // TODO: Check In and Out type and do a better type checking
-                if std::mem::size_of::<$T>() != prop_slice.buffer.len() {
-                    return Err(ParserError::LengthMismatch);
+                match prop_slice.property.info {
+                    PropertyInfo::Value { .. } => {
+                        // TODO: Check In and Out type and do a better type checking
+                        if std::mem::size_of::<$T>() != prop_slice.buffer.len() {
+                            return Err(ParserError::LengthMismatch);
+                        }
+                        Ok($T::from_ne_bytes(prop_slice.buffer.try_into()?))
+                    }
+                    _ => Err(ParserError::InvalidType),
                 }
-                Ok($T::from_ne_bytes(prop_slice.buffer.try_into()?))
+            }
+        }
+    };
+}
+
+macro_rules! impl_try_parse_primitive_array {
+    ($T:ident) => {
+        impl<'schema, 'record> private::TryParse<&'record [$T]> for Parser<'schema, 'record> {
+            fn try_parse_impl(&self, name: &str) -> ParserResult<&'record [$T]> {
+                let prop_slice = self.find_property(name)?;
+
+                match prop_slice.property.info {
+                    PropertyInfo::Array { .. } => {
+                        // TODO: Check In and Out type and do a better type checking
+                        let size = std::mem::size_of::<$T>();
+                        if prop_slice.buffer.len() % size != 0 {
+                            return Err(ParserError::LengthMismatch);
+                        }
+                        let count = prop_slice.buffer.len() / size;
+                        let slice = unsafe {
+                            std::slice::from_raw_parts(
+                                prop_slice.buffer.as_ptr() as *const $T,
+                                count,
+                            )
+                        };
+                        Ok(slice)
+                    }
+                    _ => Err(ParserError::InvalidType),
+                }
             }
         }
     };
@@ -327,10 +399,15 @@ impl_try_parse_primitive!(u32);
 impl_try_parse_primitive!(i32);
 impl_try_parse_primitive!(u64);
 impl_try_parse_primitive!(i64);
-impl_try_parse_primitive!(usize);
-impl_try_parse_primitive!(isize);
 impl_try_parse_primitive!(f32);
 impl_try_parse_primitive!(f64);
+
+impl_try_parse_primitive_array!(u16);
+impl_try_parse_primitive_array!(i16);
+impl_try_parse_primitive_array!(u32);
+impl_try_parse_primitive_array!(i32);
+impl_try_parse_primitive_array!(u64);
+impl_try_parse_primitive_array!(i64);
 
 /// The `String` impl of the `TryParse` trait should be used to retrieve the following [TdhInTypes]:
 ///
@@ -361,30 +438,36 @@ impl private::TryParse<String> for Parser<'_, '_> {
     fn try_parse_impl(&self, name: &str) -> ParserResult<String> {
         let prop_slice = self.find_property(name)?;
 
-        match prop_slice.property.in_type {
-            TdhInType::InTypeUnicodeString => {
-                if prop_slice.buffer.len() % 2 != 0 {
-                    return Err(ParserError::PropertyError(
-                        "odd length in bytes for a wide string".into(),
-                    ));
-                }
-                
-                let wide = unsafe { std::slice::from_raw_parts(
-                    prop_slice.buffer.as_ptr() as *const u16,
-                    prop_slice.buffer.len() / 2
-                )};
+        match prop_slice.property.info {
+            PropertyInfo::Value { in_type, .. } => match in_type {
+                TdhInType::InTypeUnicodeString => {
+                    if prop_slice.buffer.len() % 2 != 0 {
+                        return Err(ParserError::PropertyError(
+                            "odd length in bytes for a wide string".into(),
+                        ));
+                    }
 
-                Ok(widestring::decode_utf16_lossy(wide.iter().copied()).collect::<String>())
-            }
-            TdhInType::InTypeAnsiString => {
-                let string = std::str::from_utf8(prop_slice.buffer)?;
-                Ok(string.trim_matches(char::default()).to_string())
-            }
-            TdhInType::InTypeSid => {
-                let string = sddl::convert_sid_to_string(prop_slice.buffer.as_ptr() as *const _)?;
-                Ok(string)
-            }
-            TdhInType::InTypeCountedString => unimplemented!(),
+                    let wide = unsafe {
+                        std::slice::from_raw_parts(
+                            prop_slice.buffer.as_ptr() as *const u16,
+                            prop_slice.buffer.len() / 2,
+                        )
+                    };
+
+                    Ok(widestring::decode_utf16_lossy(wide.iter().copied()).collect::<String>())
+                }
+                TdhInType::InTypeAnsiString => {
+                    let string = std::str::from_utf8(prop_slice.buffer)?;
+                    Ok(string.trim_matches(char::default()).to_string())
+                }
+                TdhInType::InTypeSid => {
+                    let string =
+                        sddl::convert_sid_to_string(prop_slice.buffer.as_ptr() as *const _)?;
+                    Ok(string)
+                }
+                TdhInType::InTypeCountedString => unimplemented!(),
+                _ => Err(ParserError::InvalidType),
+            },
             _ => Err(ParserError::InvalidType),
         }
     }
@@ -394,20 +477,25 @@ impl private::TryParse<GUID> for Parser<'_, '_> {
     fn try_parse_impl(&self, name: &str) -> Result<GUID, ParserError> {
         let prop_slice = self.find_property(name)?;
 
-        if prop_slice.property.in_type != TdhInType::InTypeGuid {
-            return Err(ParserError::InvalidType);
-        }
+        match prop_slice.property.info {
+            PropertyInfo::Value { in_type, .. } => {
+                if in_type != TdhInType::InTypeGuid {
+                    return Err(ParserError::InvalidType);
+                }
 
-        if prop_slice.buffer.len() != 16 {
-            return Err(ParserError::LengthMismatch);
-        }
+                if prop_slice.buffer.len() != 16 {
+                    return Err(ParserError::LengthMismatch);
+                }
 
-        Ok(GUID {
-            data1: u32::from_ne_bytes(prop_slice.buffer[0..4].try_into()?),
-            data2: u16::from_ne_bytes(prop_slice.buffer[4..6].try_into()?),
-            data3: u16::from_be_bytes(prop_slice.buffer[6..8].try_into()?),
-            data4: prop_slice.buffer[8..].try_into()?,
-        })
+                Ok(GUID {
+                    data1: u32::from_ne_bytes(prop_slice.buffer[0..4].try_into()?),
+                    data2: u16::from_ne_bytes(prop_slice.buffer[4..6].try_into()?),
+                    data3: u16::from_be_bytes(prop_slice.buffer[6..8].try_into()?),
+                    data4: prop_slice.buffer[8..].try_into()?,
+                })
+            }
+            _ => Err(ParserError::InvalidType),
+        }
     }
 }
 
@@ -415,26 +503,29 @@ impl private::TryParse<IpAddr> for Parser<'_, '_> {
     fn try_parse_impl(&self, name: &str) -> ParserResult<IpAddr> {
         let prop_slice = self.find_property(name)?;
 
-        if prop_slice.property.out_type != TdhOutType::OutTypeIpv4
-            && prop_slice.property.out_type != TdhOutType::OutTypeIpv6
-        {
-            return Err(ParserError::InvalidType);
+        match prop_slice.property.info {
+            PropertyInfo::Value { out_type, .. } => {
+                if out_type != TdhOutType::OutTypeIpv4 && out_type != TdhOutType::OutTypeIpv6 {
+                    return Err(ParserError::InvalidType);
+                }
+
+                // Hardcoded values for now
+                let res = match prop_slice.buffer.len() {
+                    16 => {
+                        let tmp: [u8; 16] = prop_slice.buffer.try_into()?;
+                        IpAddr::V6(Ipv6Addr::from(tmp))
+                    }
+                    4 => {
+                        let tmp: [u8; 4] = prop_slice.buffer.try_into()?;
+                        IpAddr::V4(Ipv4Addr::from(tmp))
+                    }
+                    _ => return Err(ParserError::LengthMismatch),
+                };
+
+                Ok(res)
+            }
+            _ => Err(ParserError::InvalidType),
         }
-
-        // Hardcoded values for now
-        let res = match prop_slice.buffer.len() {
-            16 => {
-                let tmp: [u8; 16] = prop_slice.buffer.try_into()?;
-                IpAddr::V6(Ipv6Addr::from(tmp))
-            }
-            4 => {
-                let tmp: [u8; 4] = prop_slice.buffer.try_into()?;
-                IpAddr::V4(Ipv4Addr::from(tmp))
-            }
-            _ => return Err(ParserError::LengthMismatch),
-        };
-
-        Ok(res)
     }
 }
 
@@ -442,15 +533,20 @@ impl private::TryParse<bool> for Parser<'_, '_> {
     fn try_parse_impl(&self, name: &str) -> ParserResult<bool> {
         let prop_slice = self.find_property(name)?;
 
-        if prop_slice.property.in_type != TdhInType::InTypeBoolean {
-            return Err(ParserError::InvalidType);
-        }
+        match prop_slice.property.info {
+            PropertyInfo::Value { in_type, .. } => {
+                if in_type != TdhInType::InTypeBoolean {
+                    return Err(ParserError::InvalidType);
+                }
 
-        match prop_slice.buffer.len() {
-            1 => Ok(prop_slice.buffer[0] != 0),
-            4 => Ok(u32::from_ne_bytes(prop_slice.buffer.try_into()?) != 0),
-            8 => Ok(u64::from_ne_bytes(prop_slice.buffer.try_into()?) != 0),
-            _ => Err(ParserError::LengthMismatch),
+                match prop_slice.buffer.len() {
+                    1 => Ok(prop_slice.buffer[0] != 0),
+                    4 => Ok(u32::from_ne_bytes(prop_slice.buffer.try_into()?) != 0),
+                    8 => Ok(u64::from_ne_bytes(prop_slice.buffer.try_into()?) != 0),
+                    _ => Err(ParserError::LengthMismatch),
+                }
+            }
+            _ => Err(ParserError::InvalidType),
         }
     }
 }
@@ -459,11 +555,16 @@ impl private::TryParse<FileTime> for Parser<'_, '_> {
     fn try_parse_impl(&self, name: &str) -> ParserResult<FileTime> {
         let prop_slice = self.find_property(name)?;
 
-        if prop_slice.property.in_type != TdhInType::InTypeFileTime {
-            return Err(ParserError::InvalidType);
-        }
+        match prop_slice.property.info {
+            PropertyInfo::Value { in_type, .. } => {
+                if in_type != TdhInType::InTypeFileTime {
+                    return Err(ParserError::InvalidType);
+                }
 
-        Ok(FileTime::from_slice(prop_slice.buffer.try_into()?))
+                Ok(FileTime::from_slice(prop_slice.buffer.try_into()?))
+            }
+            _ => Err(ParserError::InvalidType),
+        }
     }
 }
 
@@ -471,11 +572,16 @@ impl private::TryParse<SystemTime> for Parser<'_, '_> {
     fn try_parse_impl(&self, name: &str) -> ParserResult<SystemTime> {
         let prop_slice = self.find_property(name)?;
 
-        if prop_slice.property.in_type != TdhInType::InTypeSystemTime {
-            return Err(ParserError::InvalidType);
-        }
+        match prop_slice.property.info {
+            PropertyInfo::Value { in_type, .. } => {
+                if in_type != TdhInType::InTypeSystemTime {
+                    return Err(ParserError::InvalidType);
+                }
 
-        Ok(SystemTime::from_slice(prop_slice.buffer.try_into()?))
+                Ok(SystemTime::from_slice(prop_slice.buffer.try_into()?))
+            }
+            _ => Err(ParserError::InvalidType),
+        }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -160,9 +160,7 @@ impl<'schema, 'record> Parser<'schema, 'record> {
         //    e.g.: the WinInet provider manifest has fields such as `<data name="Verb" inType="win:AnsiString" length="_VerbLength"/>`
         //    In this case, we defer to TDH to know the right length.
 
-        if property
-            .flags
-            .contains(PropertyFlags::PROPERTY_PARAM_LENGTH) == false
+        if !property.flags.contains(PropertyFlags::PROPERTY_PARAM_LENGTH)
             && (property.len() > 0)
         {
             let size = if property.in_type() != TdhInType::InTypePointer {
@@ -194,7 +192,7 @@ impl<'schema, 'record> Parser<'schema, 'record> {
                 // If a string is null-terminated, propertyLength includes the null character.
                 // If a string is not-null terminated, propertyLength includes all bytes up
                 // to the end of the record buffer.
-                if property.flags.contains(PropertyFlags::PROPERTY_STRUCT) == false
+                if !property.flags.contains(PropertyFlags::PROPERTY_STRUCT)
                 && property.out_type() == TdhOutType::OutTypeString {
                     match property.in_type() {
                         TdhInType::InTypeAnsiString => {
@@ -453,7 +451,7 @@ impl private::TryParse<bool> for Parser<'_, '_> {
             1 => Ok(prop_slice.buffer[0] != 0),
             4 => Ok(u32::from_ne_bytes(prop_slice.buffer.try_into()?) != 0),
             8 => Ok(u64::from_ne_bytes(prop_slice.buffer.try_into()?) != 0),
-            _ => return Err(ParserError::LengthMismatch),
+            _ => Err(ParserError::LengthMismatch),
         }
     }
 }

--- a/src/provider/kernel_providers.rs
+++ b/src/provider/kernel_providers.rs
@@ -253,7 +253,7 @@ mod test {
         let kernel_provider = Provider::kernel(&IMAGE_LOAD_PROVIDER).build();
 
         assert_eq!(EVENT_TRACE_FLAG_IMAGE_LOAD, kernel_provider.kernel_flags());
-        assert_eq!(GUID::from(IMAGE_LOAD_GUID), kernel_provider.guid());
+        assert_eq!(IMAGE_LOAD_GUID, kernel_provider.guid());
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -99,7 +99,7 @@ impl Schema {
     /// This is parsed on first call, and cached for later use
     pub(crate) fn properties(&self) -> &[Property] {
         match self.try_properties() {
-            Err(PropertyError::UnimplementedType) => {
+            Err(PropertyError::UnimplementedType(_)) => {
                 log::error!("Unable to list properties: a type is not implemented");
                 &[]
             }

--- a/src/schema_locator.rs
+++ b/src/schema_locator.rs
@@ -25,7 +25,7 @@ impl From<tdh::TdhNativeError> for SchemaError {
     }
 }
 
-type SchemaResult<T> = Result<T, SchemaError>;
+pub(crate) type SchemaResult<T> = Result<T, SchemaError>;
 
 /// A way to group events that share the same [`Schema`]
 ///

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,0 +1,435 @@
+//! Integrates with [serde](https://serde.rs/) enabling ['EventRecord`](crate::EventRecord) to be serialized to various formats.
+//! 
+//! Requires the `serde` feature be enabled.
+//!
+//! If the `time_rs` feature is enabled, then time stamps are serialized per the serialization format 
+//! of the time crate. Otherwise, if `time_rs` is not enabled, then timestamps are serialized as 64bit 
+//! unix timestamps.
+//! 
+//! ```
+//! use ferrisetw::schema_locator::SchemaLocator;
+//! use ferrisetw::{EventRecord, EventSerializer};
+//! extern crate serde_json;
+//! 
+//! fn event_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
+//!     match schema_locator.event_schema(record) {
+//!         Err(err) => println!("Error {:?}", err),
+//!         Ok(schema) => {
+//!             // Generate a serializer for the record using the schema
+//!             let ser = EventSerializer::new(record, &schema, Default::default());
+//!             // Pass the serializer to any serde compatible serializer
+//!             match serde_json::to_value(ser) {
+//!                 Err(err) => println!("Error {:?}", err),
+//!                 Ok(json) => println!("{}", json),
+//!             }
+//!         }
+//!     }
+//! }
+//! ```
+#![cfg(feature = "serde")]
+
+use crate::native::etw_types::event_record::EventRecord;
+use crate::native::tdh_types::{Property, TdhInType, TdhOutType};
+use crate::native::time::{FileTime, SystemTime};
+use crate::parser::Parser;
+use crate::schema::Schema;
+use crate::GUID;
+use serde::ser::{SerializeMap, SerializeStruct};
+use std::net::IpAddr;
+use windows::Win32::System::Diagnostics::Etw::{EVENT_DESCRIPTOR, EVENT_HEADER};
+
+/// Serialization options for EventSerializer
+#[derive(Clone, Copy)]
+pub struct EventSerializerOptions {
+    /// Includes information from the schema in the serialized output such as the provider, opcode, and task names.
+    pub include_schema: bool,
+    /// Includes the [EVENT_HEADER](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fa4f7836-06ee-4ab6-8688-386a5a85f8c5) in the serialized output.
+    pub include_header: bool,
+    /// Includes the set of [EVENT_HEADER_EXTENDED_DATA_ITEM](https://learn.microsoft.com/en-us/windows/win32/api/evntcons/ns-evntcons-event_header_extended_data_item) in the serialized output.
+    pub include_extended_data: bool,
+    /// When `true` unimplemented serialization fails with an error, otherwise unimplemented serialization is skipped and will not be present in the serialized output.
+    pub fail_unimplemented: bool,
+}
+
+impl core::default::Default for EventSerializerOptions {
+    fn default() -> Self {
+        Self {
+            include_schema: true,
+            include_header: true,
+            include_extended_data: false,
+            fail_unimplemented: false,
+        }
+    }
+}
+
+/// Used to serialize ['EventRecord`](crate::EventRecord) using [serde](https://serde.rs/)
+pub struct EventSerializer<'a> {
+    pub(crate) record: &'a EventRecord,
+    pub(crate) schema: &'a Schema,
+    pub(crate) parser: Parser<'a, 'a>,
+    pub(crate) options: EventSerializerOptions,
+}
+
+impl<'a> EventSerializer<'a> {
+    /// Creates an event serializer object.
+    pub fn new(
+        record: &'a EventRecord,
+        schema: &'a Schema,
+        options: EventSerializerOptions,
+    ) -> Self {
+        Self {
+            record,
+            schema,
+            parser: Parser::create(record, schema),
+            options,
+        }
+    }
+}
+
+impl serde::ser::Serialize for EventSerializer<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Record", 4)?;
+
+        if self.options.include_schema {
+            let schema = SchemaSer::new(&self.schema);
+            state.serialize_field("Schema", &schema)?;
+        } else {
+            state.skip_field("Schema")?;
+        }
+
+        if self.options.include_header {
+            let header = HeaderSer::new(&self.record.0.EventHeader);
+            state.serialize_field("Header", &header)?;
+        } else {
+            state.skip_field("Header")?;
+        }
+
+        if self.options.include_extended_data && self.options.fail_unimplemented {
+            // TODO
+            return Err(serde::ser::Error::custom(
+                "not implemented for extended data",
+            ));
+        } else {
+            state.skip_field("Extended")?;
+        }
+
+        let event = EventSer::new(&self.schema, &self.parser, &self.options);
+        state.serialize_field("Event", &event)?;
+
+        state.end()
+    }
+}
+
+struct GUIDExt(GUID);
+
+impl serde::ser::Serialize for GUIDExt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        if serializer.is_human_readable() {
+            return serializer.serialize_str(&format!("{:?}", self.0));
+        }
+
+        (self.0.data1, self.0.data2, self.0.data3, self.0.data4).serialize(serializer)
+    }
+}
+
+struct SchemaSer<'a> {
+    schema: &'a Schema,
+}
+
+impl<'a> SchemaSer<'a> {
+    fn new(schema: &'a Schema) -> Self {
+        Self { schema }
+    }
+}
+
+impl serde::ser::Serialize for SchemaSer<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Schema", 3)?;
+        state.serialize_field("Provider", &self.schema.provider_name().trim())?;
+        state.serialize_field("Opcode", &self.schema.opcode_name().trim())?;
+        state.serialize_field("Task", &self.schema.task_name().trim())?;
+        state.end()
+    }
+}
+
+struct HeaderSer<'a> {
+    header: &'a EVENT_HEADER,
+}
+
+impl<'a> HeaderSer<'a> {
+    fn new(header: &'a EVENT_HEADER) -> Self {
+        Self { header }
+    }
+}
+
+impl serde::ser::Serialize for HeaderSer<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Header", 10)?;
+        state.serialize_field("Size", &self.header.Size)?;
+        state.serialize_field("HeaderType", &self.header.HeaderType)?;
+        state.serialize_field("Flags", &self.header.Flags)?;
+        state.serialize_field("EventProperty", &self.header.Flags)?;
+        state.serialize_field("ThreadId", &self.header.ThreadId)?;
+        state.serialize_field("ProcessId", &self.header.ProcessId)?;
+        state.serialize_field("TimeStamp", &FileTime::from_quad(self.header.TimeStamp))?;
+        state.serialize_field("ProviderId", &GUIDExt(self.header.ProviderId))?;
+        state.serialize_field("ActivityId", &GUIDExt(self.header.ActivityId))?;
+        let descriptor = DescriptorSer::new(&self.header.EventDescriptor);
+        state.serialize_field("Descriptor", &descriptor)?;
+        state.end()
+    }
+}
+
+struct DescriptorSer<'a> {
+    descriptor: &'a EVENT_DESCRIPTOR,
+}
+
+impl<'a> DescriptorSer<'a> {
+    fn new(descriptor: &'a EVENT_DESCRIPTOR) -> Self {
+        Self { descriptor }
+    }
+}
+
+impl serde::ser::Serialize for DescriptorSer<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Descriptor", 7)?;
+        state.serialize_field("Id", &self.descriptor.Id)?;
+        state.serialize_field("Version", &self.descriptor.Version)?;
+        state.serialize_field("Channel", &self.descriptor.Channel)?;
+        state.serialize_field("Level", &self.descriptor.Level)?;
+        state.serialize_field("Opcode", &self.descriptor.Opcode)?;
+        state.serialize_field("Task", &self.descriptor.Task)?;
+        state.serialize_field("Keyword", &self.descriptor.Keyword)?;
+        state.end()
+    }
+}
+
+struct EventSer<'a, 'b> {
+    schema: &'a Schema,
+    parser: &'a Parser<'b, 'b>,
+    options: &'a EventSerializerOptions,
+}
+
+impl<'a, 'b> EventSer<'a, 'b> {
+    fn new(
+        schema: &'a Schema,
+        parser: &'a Parser<'b, 'b>,
+        options: &'a EventSerializerOptions,
+    ) -> Self {
+        Self {
+            schema,
+            parser,
+            options,
+        }
+    }
+}
+
+impl serde::ser::Serialize for EventSer<'_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut len: usize = 0;
+        for prop in self.schema.properties() {
+            if let Some(_) = prop.get_parser() {
+                len += 1;
+            } else if self.options.fail_unimplemented {
+                return Err(serde::ser::Error::custom(format!(
+                    "not implemented for in_typ: {:?} out_type: {:?}",
+                    prop.in_type, prop.out_type,
+                )));
+            }
+        }
+
+        let mut state = serializer.serialize_map(Some(len))?;
+        for prop in self.schema.properties() {
+            if let Some(s) = prop.get_parser() {
+                s.0.ser::<S>(&mut state, prop, &self.parser)?;
+            }
+        }
+        state.end()
+    }
+}
+
+struct PropSer(PropHandler);
+
+trait PropSerable {
+    fn get_parser(&self) -> Option<PropSer>;
+}
+
+enum PropHandler {
+    Null,
+    Bool,
+    Int8,
+    UInt8,
+    Int16,
+    UInt16,
+    Int32,
+    UInt32,
+    Int64,
+    UInt64,
+    Pointer,
+    Float,
+    Double,
+    String,
+    FileTime,
+    SystemTime,
+    GUID,
+    Binary,
+    IpAddr,
+}
+
+macro_rules! prop_ser_type {
+    ($typ:ty, $map:expr, $prop:expr, $parser:expr) => {{
+        let v = $parser
+            .try_parse::<$typ>(&$prop.name)
+            .map_err(serde::ser::Error::custom)?;
+        $map.serialize_entry(&$prop.name, &v)
+    }};
+}
+
+impl PropHandler {
+    fn ser<S>(
+        &self,
+        map: &mut S::SerializeMap,
+        prop: &Property,
+        parser: &Parser,
+    ) -> Result<(), S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        match self {
+            PropHandler::Bool => prop_ser_type!(bool, map, prop, parser),
+            PropHandler::Int8 => prop_ser_type!(i8, map, prop, parser),
+            PropHandler::UInt8 => prop_ser_type!(u8, map, prop, parser),
+            PropHandler::Int16 => prop_ser_type!(i16, map, prop, parser),
+            PropHandler::UInt16 => prop_ser_type!(u16, map, prop, parser),
+            PropHandler::Int32 => prop_ser_type!(i32, map, prop, parser),
+            PropHandler::UInt32 => prop_ser_type!(u32, map, prop, parser),
+            PropHandler::Int64 => prop_ser_type!(i64, map, prop, parser),
+            PropHandler::UInt64 => prop_ser_type!(u64, map, prop, parser),
+            PropHandler::Float => prop_ser_type!(f32, map, prop, parser),
+            PropHandler::Double => prop_ser_type!(f64, map, prop, parser),
+            PropHandler::String => prop_ser_type!(String, map, prop, parser),
+            PropHandler::Binary => prop_ser_type!(Vec<u8>, map, prop, parser),
+            PropHandler::IpAddr => prop_ser_type!(IpAddr, map, prop, parser),
+            PropHandler::FileTime => prop_ser_type!(FileTime, map, prop, parser),
+            PropHandler::SystemTime => prop_ser_type!(SystemTime, map, prop, parser),
+            PropHandler::Null => {
+                let value: Option<usize> = None;
+                map.serialize_entry(&prop.name, &value)
+            }
+            PropHandler::Pointer => {
+                if prop.length == 8 {
+                    prop_ser_type!(u64, map, prop, parser)
+                } else {
+                    prop_ser_type!(u32, map, prop, parser)
+                }
+            }
+            PropHandler::GUID => {
+                let guid = parser
+                    .try_parse::<GUID>(&prop.name)
+                    .map_err(serde::ser::Error::custom)?;
+                map.serialize_entry(&prop.name, &GUIDExt(guid))
+            }
+        }
+    }
+}
+
+impl PropSerable for TdhOutType {
+    fn get_parser(&self) -> Option<PropSer> {
+        match self {
+            Self::OutTypeNull => None, // intentionally handled by input type
+            Self::OutTypeString => Some(PropSer(PropHandler::String)),
+            Self::OutTypeDateTime => None, // intentionally handled by input type
+            Self::OutTypeInt8 => Some(PropSer(PropHandler::Int8)),
+            Self::OutTypeUInt8 => Some(PropSer(PropHandler::UInt8)),
+            Self::OutTypeInt16 => Some(PropSer(PropHandler::Int16)),
+            Self::OutTypeUInt16 => Some(PropSer(PropHandler::UInt16)),
+            Self::OutTypeInt32 => Some(PropSer(PropHandler::Int32)),
+            Self::OutTypeUInt32 => Some(PropSer(PropHandler::UInt32)),
+            Self::OutTypeInt64 => Some(PropSer(PropHandler::Int64)),
+            Self::OutTypeUInt64 => Some(PropSer(PropHandler::UInt64)),
+            Self::OutTypeFloat => Some(PropSer(PropHandler::Float)),
+            Self::OutTypeDouble => Some(PropSer(PropHandler::Double)),
+            Self::OutTypeBoolean => Some(PropSer(PropHandler::Bool)),
+            Self::OutTypeGuid => Some(PropSer(PropHandler::GUID)),
+            Self::OutTypeHexBinary => Some(PropSer(PropHandler::Binary)),
+            Self::OutTypeHexInt8 => Some(PropSer(PropHandler::Int8)),
+            Self::OutTypeHexInt16 => Some(PropSer(PropHandler::Int16)),
+            Self::OutTypeHexInt32 => Some(PropSer(PropHandler::Int32)),
+            Self::OutTypeHexInt64 => Some(PropSer(PropHandler::Int64)),
+            Self::OutTypePid => Some(PropSer(PropHandler::UInt32)),
+            Self::OutTypeTid => Some(PropSer(PropHandler::UInt32)),
+            Self::OutTypePort => Some(PropSer(PropHandler::UInt16)),
+            Self::OutTypeIpv4 => Some(PropSer(PropHandler::IpAddr)),
+            Self::OutTypeIpv6 => Some(PropSer(PropHandler::IpAddr)),
+            Self::OutTypeWin32Error => Some(PropSer(PropHandler::UInt32)),
+            Self::OutTypeNtStatus => Some(PropSer(PropHandler::Int32)),
+            Self::OutTypeHResult => Some(PropSer(PropHandler::Int32)),
+            Self::OutTypeJson => None, // TODO
+            Self::OutTypeUtf8 => Some(PropSer(PropHandler::String)),
+            Self::OutTypePkcs7 => None, // TODO
+            Self::OutTypeCodePointer => Some(PropSer(PropHandler::Pointer)),
+            Self::OutTypeDatetimeUtc => None, // intentionally handled by input type
+        }
+    }
+}
+
+impl PropSerable for TdhInType {
+    fn get_parser(&self) -> Option<PropSer> {
+        match self {
+            Self::InTypeNull => Some(PropSer(PropHandler::Null)),
+            Self::InTypeUnicodeString => Some(PropSer(PropHandler::String)),
+            Self::InTypeAnsiString => Some(PropSer(PropHandler::String)),
+            Self::InTypeInt8 => Some(PropSer(PropHandler::Int8)),
+            Self::InTypeUInt8 => Some(PropSer(PropHandler::UInt8)),
+            Self::InTypeInt16 => Some(PropSer(PropHandler::Int16)),
+            Self::InTypeUInt16 => Some(PropSer(PropHandler::UInt16)),
+            Self::InTypeInt32 => Some(PropSer(PropHandler::Int32)),
+            Self::InTypeUInt32 => Some(PropSer(PropHandler::UInt32)),
+            Self::InTypeInt64 => Some(PropSer(PropHandler::Int64)),
+            Self::InTypeUInt64 => Some(PropSer(PropHandler::UInt64)),
+            Self::InTypeFloat => Some(PropSer(PropHandler::Float)),
+            Self::InTypeDouble => Some(PropSer(PropHandler::Double)),
+            Self::InTypeBoolean => Some(PropSer(PropHandler::Bool)),
+            Self::InTypeBinary => Some(PropSer(PropHandler::Binary)),
+            Self::InTypeGuid => Some(PropSer(PropHandler::GUID)),
+            Self::InTypePointer => Some(PropSer(PropHandler::Pointer)),
+            Self::InTypeFileTime => Some(PropSer(PropHandler::FileTime)),
+            Self::InTypeSystemTime => Some(PropSer(PropHandler::SystemTime)),
+            Self::InTypeSid => Some(PropSer(PropHandler::String)),
+            Self::InTypeHexInt32 => Some(PropSer(PropHandler::Int32)),
+            Self::InTypeHexInt64 => Some(PropSer(PropHandler::Int64)),
+            Self::InTypeCountedString => None, // TODO
+        }
+    }
+}
+
+impl PropSerable for Property {
+    fn get_parser(&self) -> Option<PropSer> {
+        // give the output type parser first, if there is one otherwise use the input type
+        if let Some(p) = self.out_type.get_parser() {
+            Some(p)
+        } else if let Some(p) = self.in_type.get_parser() {
+            Some(p)
+        } else {
+            None
+        }
+    }
+}

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -402,7 +402,7 @@ impl<T: RealTimeTraceTrait + PrivateRealTimeTraceTrait> TraceBuilder<T> {
     ///
     /// Note: this trace name may be truncated to a few hundred characters if it is too long.
     pub fn named(mut self, name: String) -> Self {
-        if T::TRACE_KIND == private::TraceKind::Kernel && version_helper::is_win8_or_greater() == false {
+        if T::TRACE_KIND == private::TraceKind::Kernel && !version_helper::is_win8_or_greater() {
             self.name = String::from(KERNEL_LOGGER_NAME);
         } else {
             self.name = name;
@@ -521,6 +521,7 @@ impl<T: RealTimeTraceTrait + PrivateRealTimeTraceTrait> TraceBuilder<T> {
 
 impl FileTrace {
     /// Create a trace that will read events from a file
+    #[allow(clippy::new_ret_no_self)]
     pub fn new<T>(path: PathBuf, callback: T) -> FileTraceBuilder
         where T: FnMut(&EventRecord, &SchemaLocator) + Send + Sync + 'static,
     {

--- a/src/trace/callback_data.rs
+++ b/src/trace/callback_data.rs
@@ -53,13 +53,19 @@ impl CallbackData {
     }
 }
 
-impl RealTimeCallbackData {
-    pub fn new() -> Self {
+impl std::default::Default for RealTimeCallbackData {
+    fn default() -> Self {
         Self {
             events_handled: AtomicUsize::new(0),
             schema_locator: SchemaLocator::new(),
             providers: Vec::new(),
         }
+    }
+}
+
+impl RealTimeCallbackData {
+    pub fn new() -> Self {
+        Default::default()
     }
 
     pub fn add_provider(&mut self, provider: Provider) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,17 +8,3 @@ pub fn rand_string() -> String {
         .map(char::from)
         .collect()
 }
-
-pub fn parse_utf16_guid(v: &[u8]) -> String {
-    String::from_utf16_lossy(
-        v.chunks_exact(2)
-            .into_iter()
-            .map(|a| u16::from_ne_bytes([a[0], a[1]]))
-            .collect::<Vec<u16>>()
-            .as_slice(),
-    )
-    .trim_matches(char::default())
-    .trim_matches('{')
-    .trim_matches('}')
-    .to_string()
-}

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -139,7 +139,7 @@ fn has_seen_resolution_to_test_domain(record: &EventRecord, parser: &Parser) -> 
     if record.event_id() == EVENT_ID_DNS_QUERY_INITIATED {
         let query_name: String = parser.try_parse("QueryName").unwrap();
         #[allow(unused_parens)]
-        return (&query_name == TEST_DOMAIN_NAME);
+        return (query_name == TEST_DOMAIN_NAME);
     }
     false
 }

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -247,6 +247,7 @@ fn serialize_json() {
             //include_schema: false,
             //include_header: false,
             //include_extended_data: false,
+            //fail_unimplemented: true,
             ..Default::default()
         },
         SECONDS_TO_RUN,
@@ -261,6 +262,7 @@ fn serialize_flexbuffer() {
             //include_schema: false,
             //include_header: false,
             //include_extended_data: false,
+            //fail_unimplemented: true,
             ..Default::default()
         },
         SECONDS_TO_RUN,

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -103,6 +103,7 @@ impl BenchmarkStatistics {
         let event = EventSerializer::new(record, &schema, options);
         let res = serde_json::to_value(event);
         if res.is_err() {
+            println!("{:?}", res);
             self.error_count.fetch_add(1, Ordering::AcqRel);
             return;
         }
@@ -131,6 +132,7 @@ impl BenchmarkStatistics {
         let mut ser = flexbuffers::FlexbufferSerializer::new();
         let res = event.serialize(&mut ser);
         if res.is_err() {
+            println!("{:?}", res);
             self.error_count.fetch_add(1, Ordering::AcqRel);
             return;
         }

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-static BENCHMARK_PROVIDERS: &'static [&'static str] = &[
+static BENCHMARK_PROVIDERS: &[&str] = &[
     "C514638F-7723-485B-BCFC-96565D735D4A",
     "16A1ADC1-9B7F-4CD9-94B3-D8296AB1B130",
     "E02A841C-75A3-4FA7-AFC8-AE09CF9B7F23",
@@ -201,7 +201,7 @@ fn ser_json_test(name: &'static str, options: EventSerializerOptions, seconds_to
     let mut trace_builder = UserTrace::new().named(name.to_string());
     for guid in BENCHMARK_PROVIDERS {
         let s = stats.clone();
-        let opts = options.clone();
+        let opts = options;
         trace_builder = trace_builder.enable(
             Provider::by_guid(*guid)
                 .add_callback(move |record, schema_locator| {
@@ -224,7 +224,7 @@ fn ser_flexbuffer_test(name: &'static str, options: EventSerializerOptions, seco
     let mut trace_builder = UserTrace::new().named(name.to_string());
     for guid in BENCHMARK_PROVIDERS {
         let s = stats.clone();
-        let opts = options.clone();
+        let opts = options;
         trace_builder = trace_builder.enable(
             Provider::by_guid(*guid)
                 .add_callback(move |record, schema_locator| {

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -1,0 +1,268 @@
+#![cfg(feature = "serde")]
+
+use ferrisetw::provider::Provider;
+use ferrisetw::schema_locator::SchemaLocator;
+use ferrisetw::trace::{stop_trace_by_name, TraceBuilder, TraceTrait, UserTrace};
+use ferrisetw::{EventRecord, EventSerializer, EventSerializerOptions};
+use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+static BENCHMARK_PROVIDERS: &'static [&'static str] = &[
+    "C514638F-7723-485B-BCFC-96565D735D4A",
+    "16A1ADC1-9B7F-4CD9-94B3-D8296AB1B130",
+    "E02A841C-75A3-4FA7-AFC8-AE09CF9B7F23",
+    "15CA44FF-4D7A-4BAA-BBA5-0998955E531E",
+    "96AC7637-5950-4A30-B8F7-E07E8E5734C1",
+    "A2D34BF1-70AB-5B21-C819-5A0DD42748FD",
+    "7F54CA8A-6C72-5CBC-B96F-D0EF905B8BCE",
+    "C7BDE69A-E1E0-4177-B6EF-283AD1525271",
+    "17D2A329-4539-5F4D-3435-F510634CE3B9",
+    "B675EC37-BDB6-4648-BC92-F3FDC74D3CA2",
+    "EDD08927-9CC4-4E65-B970-C2560FB5C289",
+    "A68CA8B7-004F-D7B6-A698-07E2DE0F1F5D",
+    "951B41EA-C830-44DC-A671-E2C9958809B8",
+    "ABF1F586-2E50-4BA8-928D-49044E6F0DB7",
+    "A103CABD-8242-4A93-8DF5-1CDF3B3F26A6",
+    "A0AF438F-4431-41CB-A675-A265050EE947",
+    "BEF2AA8E-81CD-11E2-A7BB-5EAC6188709B",
+    "D1D93EF7-E1F2-4F45-9943-03D245FE6C00",
+    "7DD42A49-5329-4832-8DFD-43D979153A88",
+    "5412704E-B2E1-4624-8FFD-55777B8F7373",
+    "9C205A39-1250-487D-ABD7-E831C6290539",
+    "B3A0C2C8-83BB-4DDF-9F8D-4B22D3C38AD7",
+    "331C3B3A-2005-44C2-AC5E-77220C37D6B4",
+    "AA1F73E8-15FD-45D2-ABFD-E7F64F78EB11",
+    "5322D61A-9EFA-4BC3-A3F9-14BE95C144F8",
+    "B931ED29-66F4-576E-0579-0B8818A5DC6B",
+    "22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716",
+    "0F67E49F-FE51-4E9F-B490-6F2948CC6027",
+    "70EB4F03-C1DE-4F73-A051-33D13D5413BD",
+    "0BF2FB94-7B60-4B4D-9766-E82F658DF540",
+    "A6AD76E3-867A-4635-91B3-4904BA6374D7",
+    "548C4417-CE45-41FF-99DD-528F01CE0FE1",
+    "4CEC9C95-A65F-4591-B5C4-30100E51D870",
+    "2FF3E6B7-CB90-4700-9621-443F389734ED",
+    "7B563579-53C8-44E7-8236-0F87B9FE6594",
+    "F029AC39-38F0-4A40-B7DE-404D244004CB",
+    "84DE80EB-86E8-4FF6-85A6-9319ABD578A4",
+    "8939299F-2315-4C5C-9B91-ABB86AA0627D",
+    "85FE7609-FF4A-48E9-9D50-12918E43E1DA",
+    "CB070027-1534-4CF3-98EA-B9751F508376",
+    "7237FFF9-A08A-4804-9C79-4A8704B70B87",
+    "4FCC72A9-D7CA-5DD2-8D34-6F41A0CDB7E0",
+    "099614A5-5DD7-4788-8BC9-E29F43DB28FC",
+    "73AA0094-FACB-4AEB-BD1D-A7B98DD5C799",
+    "DCBFB8F0-CD19-4F1C-A27D-23AC706DED72",
+    "05F02597-FE85-4E67-8542-69567AB8FD4F",
+    "CCC64809-6B5F-4C1B-AB39-336904DA9B3B",
+    "0741C7BE-DAAC-4A5B-B00A-4BD9A2D89D0E",
+    "E159FC63-02FE-42F3-A234-028B9B8561CB",
+    "93C05D69-51A3-485E-877F-1806A8731346",
+    "C882FF1D-7585-4B33-B135-95C577179137",
+    "A329CF81-57EC-46ED-AB7C-261A52B0754A",
+];
+
+struct BenchmarkStatistics {
+    success_count: AtomicU64,
+    error_count: AtomicU64,
+    byte_count: AtomicU64,
+}
+
+impl BenchmarkStatistics {
+    fn new() -> Self {
+        Self {
+            success_count: AtomicU64::new(0),
+            error_count: AtomicU64::new(0),
+            byte_count: AtomicU64::new(0),
+        }
+    }
+
+    fn snap(&self) -> (u64, u64, u64) {
+        (
+            self.success_count.load(Ordering::Acquire),
+            self.error_count.load(Ordering::Acquire),
+            self.byte_count.load(Ordering::Acquire),
+        )
+    }
+
+    fn json_callback(
+        &self,
+        record: &EventRecord,
+        schema_locator: &SchemaLocator,
+        options: EventSerializerOptions,
+    ) {
+        let res = schema_locator.event_schema(record);
+        if res.is_err() {
+            self.error_count.fetch_add(1, Ordering::AcqRel);
+            return;
+        }
+        let schema = res.unwrap();
+
+        let event = EventSerializer::new(record, &schema, options);
+        let res = serde_json::to_value(event);
+        if res.is_err() {
+            self.error_count.fetch_add(1, Ordering::AcqRel);
+            return;
+        }
+
+        let json_string = res.unwrap().to_string();
+        //println!("{}", json_string);
+        self.success_count.fetch_add(1, Ordering::AcqRel);
+        self.byte_count
+            .fetch_add(json_string.len() as u64, Ordering::AcqRel);
+    }
+
+    fn flexbuffer_callback(
+        &self,
+        record: &EventRecord,
+        schema_locator: &SchemaLocator,
+        options: EventSerializerOptions,
+    ) {
+        let res = schema_locator.event_schema(record);
+        if res.is_err() {
+            self.error_count.fetch_add(1, Ordering::AcqRel);
+            return;
+        }
+        let schema = res.unwrap();
+
+        let event = EventSerializer::new(record, &schema, options);
+        let mut ser = flexbuffers::FlexbufferSerializer::new();
+        let res = event.serialize(&mut ser);
+        if res.is_err() {
+            self.error_count.fetch_add(1, Ordering::AcqRel);
+            return;
+        }
+
+        self.success_count.fetch_add(1, Ordering::AcqRel);
+        self.byte_count
+            .fetch_add(ser.view().len() as u64, Ordering::AcqRel);
+    }
+}
+
+fn do_benchmark(
+    name: &str,
+    stats: Arc<BenchmarkStatistics>,
+    trace_builder: TraceBuilder<UserTrace>,
+    seconds_to_run: u64,
+) {
+    let (trace, trace_handle) = trace_builder.start().expect("unable to start trace");
+
+    let thread = std::thread::spawn(move || UserTrace::process_from_handle(trace_handle));
+
+    let clock = Instant::now();
+    let mut now: Option<Instant> = None;
+    let (mut last_s, mut last_e, mut last_b) = stats.snap();
+    loop {
+        let (s, e, b) = stats.snap();
+
+        if let Some(now) = now {
+            let micros = now.elapsed().as_micros();
+            println!(
+                "{:<32}: {} b/s {} s/s {} e/s",
+                name,
+                (((b - last_b) * 1_000_000) as u128) / micros,
+                (((s - last_s) * 1_000_000) as u128) / micros,
+                (((e - last_e) * 1_000_000) as u128) / micros,
+            );
+        }
+
+        (last_s, last_e, last_b) = (s, e, b);
+        now = Some(Instant::now());
+
+        if clock.elapsed().as_secs() > seconds_to_run {
+            break;
+        }
+
+        std::thread::sleep(Duration::from_secs(1));
+    }
+
+    trace.stop().expect("unable to stop trace");
+    thread
+        .join()
+        .expect("thread panic")
+        .expect("trace processing error");
+
+    println!(
+        "{:<32}: {} b {} s {} e",
+        name, last_b, last_s, last_e
+    );
+    assert_eq!(last_e, 0, "encountered errors when benchmarking");
+}
+
+fn ser_json_test(name: &'static str, options: EventSerializerOptions, seconds_to_run: u64) {
+    if stop_trace_by_name(name).is_ok() {
+        println!("Trace was running, it has been stopped before starting it again.");
+    }
+
+    let stats = Arc::new(BenchmarkStatistics::new());
+
+    let mut trace_builder = UserTrace::new().named(name.to_string());
+    for guid in BENCHMARK_PROVIDERS {
+        let s = stats.clone();
+        let opts = options.clone();
+        trace_builder = trace_builder.enable(
+            Provider::by_guid(*guid)
+                .add_callback(move |record, schema_locator| {
+                    s.json_callback(record, schema_locator, opts)
+                })
+                .build(),
+        );
+    }
+
+    do_benchmark(name, stats, trace_builder, seconds_to_run)
+}
+
+fn ser_flexbuffer_test(name: &'static str, options: EventSerializerOptions, seconds_to_run: u64) {
+    if stop_trace_by_name(name).is_ok() {
+        println!("Trace was running, it has been stopped before starting it again.");
+    }
+
+    let stats = Arc::new(BenchmarkStatistics::new());
+
+    let mut trace_builder = UserTrace::new().named(name.to_string());
+    for guid in BENCHMARK_PROVIDERS {
+        let s = stats.clone();
+        let opts = options.clone();
+        trace_builder = trace_builder.enable(
+            Provider::by_guid(*guid)
+                .add_callback(move |record, schema_locator| {
+                    s.flexbuffer_callback(record, schema_locator, opts)
+                })
+                .build(),
+        );
+    }
+
+    do_benchmark(name, stats, trace_builder, seconds_to_run)
+}
+
+const SECONDS_TO_RUN: u64 = 5;
+
+#[test]
+fn serialize_json() {
+    ser_json_test(
+        "ferrisetw-json",
+        EventSerializerOptions {
+            //include_schema: false,
+            //include_header: false,
+            //include_extended_data: false,
+            ..Default::default()
+        },
+        SECONDS_TO_RUN,
+    );
+}
+
+#[test]
+fn serialize_flexbuffer() {
+    ser_flexbuffer_test(
+        "ferrisetw-flex",
+        EventSerializerOptions {
+            //include_schema: false,
+            //include_header: false,
+            //include_extended_data: false,
+            ..Default::default()
+        },
+        SECONDS_TO_RUN,
+    );
+}

--- a/tests/trace_lifetime.rs
+++ b/tests/trace_lifetime.rs
@@ -55,7 +55,7 @@ fn trace_lifetime() {
                         how_to_process);
 
                     // Regardless of whether we explicitly stopped it, trace has been dropped and must no longer run
-                    assert_trace_exists(&ascii_part_to_look_for, false);
+                    assert_trace_exists(ascii_part_to_look_for, false);
                 }
             }
         }
@@ -97,8 +97,7 @@ fn test_wordpad_trace(
             trace
         },
         HowToProcess::StartAndProcess => {
-            let trace = trace_builder.start_and_process().unwrap();
-            trace
+            trace_builder.start_and_process().unwrap()
         }
     };
 
@@ -131,14 +130,13 @@ fn assert_trace_exists(ascii_part_of_the_trace_name: &str, expected: bool) {
         let res = stdout
             .split('\n')
             .any(|line| {
-                let val = line.contains(&ascii_part_of_the_trace_name);
-                val
+                line.contains(ascii_part_of_the_trace_name)
             });
 
         if status.success() {
             if res != expected {
                 println!("logman output (returned {}): {}", status, stdout);
-                assert!(false);
+                unreachable!();
             }
         } else {
             // Not sure why, but logman sometimes fails to list current traces (with "The GUID passed was not recognized as valid by a WMI data provider.")


### PR DESCRIPTION
The following PR integrates with [serde](https://serde.rs/). This enables `EventRecord` to be serialized to a variety of formats supported by `serde`.

The serialization support is implemented as a feature. Users wanting the serialization features must enable the `serde` feature for this crate. The bulk of the feature is implemented in `ser.rs`. The serialization feature is used as follows:

```Rust
use ferrisetw::schema_locator::SchemaLocator;
use ferrisetw::{EventRecord, EventSerializer};
extern crate serde_json;

fn event_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
    match schema_locator.event_schema(record) {
        Err(err) => println!("Error {:?}", err),
        Ok(schema) => {
            // Generate a serializer for the record using the schema
            let ser = EventSerializer::new(record, &schema, Default::default());
            // Pass the serializer to any serde compatible serializer
            match serde_json::to_value(ser) {
                Err(err) => println!("Error {:?}", err),
                Ok(json) => println!("{}", json),
            }
        }
    }
}
```

There are two commits in the PR, the first one implements the serialization feature (https://github.com/n4r1b/ferrisetw/commit/2fae22486b960dc6eb5a0254b28634c831f24da2), the second commit (https://github.com/n4r1b/ferrisetw/commit/826855fc233dd4f03140a817b56f5eb623467b49) corrects the code based on clippy analysis `cargo clippy --tests --all-targets --all-features -- -D warnings` . I broke up the commits since the later is more or less superfluous cleanup. It might be best to review them separately.