### PR TITLE
Standardize formatting with `cargo fmt`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,11 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    # Cargo fmt check
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --check
     # Cargo check
     - uses: actions-rs/cargo@v1
       with:

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -1,35 +1,28 @@
-use std::time::Duration;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
+use ferrisetw::parser::Parser;
 use ferrisetw::provider::Provider;
 use ferrisetw::provider::TraceFlags;
-use ferrisetw::parser::Parser;
-use ferrisetw::schema_locator::SchemaLocator;
-use ferrisetw::EventRecord;
-use ferrisetw::trace::UserTrace;
 use ferrisetw::schema::Schema;
-
+use ferrisetw::schema_locator::SchemaLocator;
+use ferrisetw::trace::UserTrace;
+use ferrisetw::EventRecord;
 
 static N_EVENTS: AtomicU32 = AtomicU32::new(0);
 
-fn dns_etw_callback(
-    record: &EventRecord,
-    schema_locator: &SchemaLocator,
-) {
+fn dns_etw_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
     N_EVENTS.fetch_add(1, Ordering::SeqCst);
 
     match schema_locator.event_schema(record) {
         Err(err) => {
-            println!(
-                "Unable to get the ETW schema for a DNS event: {:?}",
-                err
-            );
-        },
+            println!("Unable to get the ETW schema for a DNS event: {:?}", err);
+        }
 
         Ok(schema) => {
             parse_etw_event(&schema, record);
-        },
+        }
     }
 }
 
@@ -37,38 +30,36 @@ fn parse_etw_event(schema: &Schema, record: &EventRecord) {
     let parser = Parser::create(record, schema);
     // let event_timestamp = filetime_to_datetime(schema.timestamp());
 
-    let requested_fqdn: Option<String> = parser
-        .try_parse("QueryName")
-        .ok();
-    let query_type: Option<u32> = parser
-        .try_parse("QueryType")
-        .ok();
-    let query_options: Option<u64> = parser
-        .try_parse("QueryOptions")
-        .ok();
+    let requested_fqdn: Option<String> = parser.try_parse("QueryName").ok();
+    let query_type: Option<u32> = parser.try_parse("QueryType").ok();
+    let query_options: Option<u64> = parser.try_parse("QueryOptions").ok();
     let query_status: Option<u32> = parser
         .try_parse("QueryStatus")
         .or_else(|_err| parser.try_parse("Status"))
         .ok();
-    let query_results: Option<String> = parser
-        .try_parse("QueryResults")
-        .ok();
+    let query_results: Option<String> = parser.try_parse("QueryResults").ok();
 
-    println!("{:4} {:4}  {:16} {:2} {:10} {}",
+    println!(
+        "{:4} {:4}  {:16} {:2} {:10} {}",
         record.event_id(),
         query_status.map(|u| u.to_string()).unwrap_or_default(),
-        query_options.map(|u| format!("{:16x}", u)).unwrap_or_default(),
+        query_options
+            .map(|u| format!("{:16x}", u))
+            .unwrap_or_default(),
         query_type.map(|u| format!("{:2}", u)).unwrap_or_default(),
-        requested_fqdn.map(|s| truncate(&s, 10).to_owned()).unwrap_or_default(),
-        query_results.map(|s| truncate(&s, 30).to_owned()).unwrap_or_default(),
+        requested_fqdn
+            .map(|s| truncate(&s, 10).to_owned())
+            .unwrap_or_default(),
+        query_results
+            .map(|s| truncate(&s, 30).to_owned())
+            .unwrap_or_default(),
     );
 }
 
 fn main() {
     env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
 
-    let dns_provider = Provider
-        ::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
+    let dns_provider = Provider::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
         .add_callback(dns_etw_callback)
         .trace_flags(TraceFlags::EVENT_ENABLE_PROPERTY_PROCESS_START_KEY)
         .build();
@@ -89,6 +80,6 @@ fn main() {
 fn truncate(s: &str, n: usize) -> &str {
     match s.get(..n) {
         Some(x) => x,
-        None => s
+        None => s,
     }
 }

--- a/examples/kernel_trace.rs
+++ b/examples/kernel_trace.rs
@@ -1,8 +1,8 @@
-use ferrisetw::EventRecord;
 use ferrisetw::parser::Parser;
 use ferrisetw::provider::*;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::*;
+use ferrisetw::EventRecord;
 use std::time::Duration;
 
 fn main() {
@@ -28,8 +28,7 @@ fn main() {
             Err(err) => println!("Error {:?}", err),
         };
 
-    let provider = Provider
-        ::kernel(&kernel_providers::IMAGE_LOAD_PROVIDER)
+    let provider = Provider::kernel(&kernel_providers::IMAGE_LOAD_PROVIDER)
         .add_callback(image_load_callback)
         .build();
 

--- a/examples/multiple_providers.rs
+++ b/examples/multiple_providers.rs
@@ -1,8 +1,8 @@
-use ferrisetw::EventRecord;
 use ferrisetw::parser::{Parser, Pointer};
 use ferrisetw::provider::*;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::*;
+use ferrisetw::EventRecord;
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
 
@@ -52,13 +52,11 @@ fn tcpip_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
 fn main() {
     env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
 
-    let tcpip_provider = Provider
-        ::by_guid("7dd42a49-5329-4832-8dfd-43d979153a88") // Microsoft-Windows-Kernel-Network
+    let tcpip_provider = Provider::by_guid("7dd42a49-5329-4832-8dfd-43d979153a88") // Microsoft-Windows-Kernel-Network
         .add_callback(tcpip_callback)
         .build();
 
-    let process_provider = Provider
-        ::by_guid("70eb4f03-c1de-4f73-a051-33d13d5413bd") // Microsoft-Windows-Kernel-Registry
+    let process_provider = Provider::by_guid("70eb4f03-c1de-4f73-a051-33d13d5413bd") // Microsoft-Windows-Kernel-Registry
         .add_callback(registry_callback)
         .build();
 

--- a/examples/user_trace.rs
+++ b/examples/user_trace.rs
@@ -1,8 +1,8 @@
-use ferrisetw::EventRecord;
 use ferrisetw::parser::Parser;
 use ferrisetw::provider::*;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::*;
+use ferrisetw::EventRecord;
 use std::time::Duration;
 
 fn main() {
@@ -30,8 +30,7 @@ fn main() {
             Err(err) => println!("Error {:?}", err),
         };
 
-    let process_provider = Provider
-        ::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
+    let process_provider = Provider::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
         .add_callback(process_callback)
         .build();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,21 +120,21 @@ pub mod provider;
 pub mod query;
 pub mod schema;
 pub mod schema_locator;
+pub mod ser;
 pub mod trace;
 mod traits;
 mod utils;
-pub mod ser;
 
 pub(crate) type EtwCallback = Box<dyn FnMut(&EventRecord, &SchemaLocator) + Send + Sync + 'static>;
 
 // Convenience re-exports.
-pub use crate::trace::UserTrace;
-pub use crate::trace::KernelTrace;
-pub use crate::trace::FileTrace;
 pub use crate::native::etw_types::event_record::EventRecord;
 pub use crate::schema_locator::SchemaLocator;
 #[cfg(feature = "serde")]
 pub use crate::ser::{EventSerializer, EventSerializerOptions};
+pub use crate::trace::FileTrace;
+pub use crate::trace::KernelTrace;
+pub use crate::trace::UserTrace;
 
 // These types are returned by some public APIs of this crate.
 // They must be re-exported, so that users of the crate have a way to avoid version conflicts

--- a/src/native/etw_types/event_record.rs
+++ b/src/native/etw_types/event_record.rs
@@ -107,13 +107,10 @@ impl EventRecord {
 
     pub(crate) fn user_buffer(&self) -> &[u8] {
         unsafe {
-            std::slice::from_raw_parts(
-                self.0.UserData as *mut _,
-                self.0.UserDataLength.into(),
-            )
+            std::slice::from_raw_parts(self.0.UserData as *mut _, self.0.UserDataLength.into())
         }
     }
-    
+
     pub(crate) fn pointer_size(&self) -> usize {
         if self.event_flags() & EVENT_HEADER_FLAG_32_BIT_HEADER != 0 {
             4
@@ -153,7 +150,8 @@ impl EventRecord {
         unsafe {
             std::slice::from_raw_parts(
                 p_ed_array as *const EventHeaderExtendedDataItem,
-                n_extended_data as usize)
+                n_extended_data as usize,
+            )
         }
     }
 }

--- a/src/native/etw_types/extended_data.rs
+++ b/src/native/etw_types/extended_data.rs
@@ -1,33 +1,27 @@
 //! A module to handle Extended Data from ETW traces
 
 use windows::core::GUID;
-use windows::Win32::System::Diagnostics::Etw::{
-    EVENT_HEADER_EXTENDED_DATA_ITEM,
-    EVENT_HEADER_EXT_TYPE_SID,
-    EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID,
-    EVENT_HEADER_EXT_TYPE_TS_ID,
-    EVENT_HEADER_EXT_TYPE_INSTANCE_INFO,
-    EVENT_HEADER_EXT_TYPE_STACK_TRACE32,
-    EVENT_HEADER_EXT_TYPE_STACK_TRACE64,
-    EVENT_HEADER_EXT_TYPE_EVENT_KEY,
-    EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY,
-};
-use windows::Win32::System::Diagnostics::Etw::{
-    EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID,
-    EVENT_EXTENDED_ITEM_TS_ID,
-};
 use windows::Win32::Security::SID;
+use windows::Win32::System::Diagnostics::Etw::{
+    EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID, EVENT_EXTENDED_ITEM_TS_ID,
+};
+use windows::Win32::System::Diagnostics::Etw::{
+    EVENT_HEADER_EXTENDED_DATA_ITEM, EVENT_HEADER_EXT_TYPE_EVENT_KEY,
+    EVENT_HEADER_EXT_TYPE_INSTANCE_INFO, EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY,
+    EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID, EVENT_HEADER_EXT_TYPE_SID,
+    EVENT_HEADER_EXT_TYPE_STACK_TRACE32, EVENT_HEADER_EXT_TYPE_STACK_TRACE64,
+    EVENT_HEADER_EXT_TYPE_TS_ID,
+};
 
 // These types are returned by our public API. Let's use their re-exported versions
 use crate::native::{
-    EVENT_EXTENDED_ITEM_INSTANCE,
-    EVENT_EXTENDED_ITEM_STACK_TRACE32,
+    EVENT_EXTENDED_ITEM_INSTANCE, EVENT_EXTENDED_ITEM_STACK_TRACE32,
     EVENT_EXTENDED_ITEM_STACK_TRACE64,
 };
 
 /// A wrapper over [`windows::Win32::System::Diagnostics::Etw::EVENT_HEADER_EXTENDED_DATA_ITEM`]
 #[repr(transparent)]
-pub struct EventHeaderExtendedDataItem (EVENT_HEADER_EXTENDED_DATA_ITEM);
+pub struct EventHeaderExtendedDataItem(EVENT_HEADER_EXTENDED_DATA_ITEM);
 
 /// A safe representation of an ExtendedDataItem
 ///
@@ -77,42 +71,42 @@ impl EventHeaderExtendedDataItem {
         match self.0.ExtType as u32 {
             EVENT_HEADER_EXT_TYPE_RELATED_ACTIVITYID => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_RELATED_ACTIVITYID;
-                ExtendedDataItem::RelatedActivityId( unsafe{ *data_ptr }.RelatedActivityId )
+                ExtendedDataItem::RelatedActivityId(unsafe { *data_ptr }.RelatedActivityId)
             }
 
             EVENT_HEADER_EXT_TYPE_SID => {
                 let data_ptr = data_ptr as *const SID;
-                ExtendedDataItem::Sid( unsafe{ *data_ptr } )
+                ExtendedDataItem::Sid(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_TS_ID => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_TS_ID;
-                ExtendedDataItem::TsId( unsafe{ *data_ptr }.SessionId )
+                ExtendedDataItem::TsId(unsafe { *data_ptr }.SessionId)
             }
 
             EVENT_HEADER_EXT_TYPE_INSTANCE_INFO => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_INSTANCE;
-                ExtendedDataItem::InstanceInfo( unsafe{ *data_ptr } )
+                ExtendedDataItem::InstanceInfo(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_STACK_TRACE32 => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_STACK_TRACE32;
-                ExtendedDataItem::StackTrace32( unsafe{ *data_ptr } )
+                ExtendedDataItem::StackTrace32(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_STACK_TRACE64 => {
                 let data_ptr = data_ptr as *const EVENT_EXTENDED_ITEM_STACK_TRACE64;
-                ExtendedDataItem::StackTrace64( unsafe{ *data_ptr } )
+                ExtendedDataItem::StackTrace64(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_PROCESS_START_KEY => {
                 let data_ptr = data_ptr as *const u64;
-                ExtendedDataItem::ProcessStartKey( unsafe{ *data_ptr } )
+                ExtendedDataItem::ProcessStartKey(unsafe { *data_ptr })
             }
 
             EVENT_HEADER_EXT_TYPE_EVENT_KEY => {
                 let data_ptr = data_ptr as *const u64;
-                ExtendedDataItem::EventKey( unsafe{ *data_ptr } )
+                ExtendedDataItem::EventKey(unsafe { *data_ptr })
             }
 
             _ => ExtendedDataItem::Unsupported,

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -7,23 +7,22 @@ pub(crate) mod pla;
 pub(crate) mod sddl;
 pub(crate) mod tdh;
 pub(crate) mod tdh_types;
-pub(crate) mod version_helper;
 pub mod time;
+pub(crate) mod version_helper;
 
 // These are used in our custom error types, and must be part of the public API
+pub use evntrace::EvntraceNativeError;
 pub use pla::PlaError;
 pub use sddl::SddlNativeError;
 pub use tdh::TdhNativeError;
-pub use evntrace::EvntraceNativeError;
 
 // These are returned by some of our public APIs
-pub use etw_types::DecodingSource;
-pub use etw_types::extended_data::ExtendedDataItem;
 pub use etw_types::extended_data::EventHeaderExtendedDataItem;
-pub use evntrace::TraceHandle;
+pub use etw_types::extended_data::ExtendedDataItem;
+pub use etw_types::DecodingSource;
 pub use evntrace::ControlHandle;
+pub use evntrace::TraceHandle;
 pub use windows::Win32::System::Diagnostics::Etw::{
-    EVENT_EXTENDED_ITEM_INSTANCE,
-    EVENT_EXTENDED_ITEM_STACK_TRACE32,
+    EVENT_EXTENDED_ITEM_INSTANCE, EVENT_EXTENDED_ITEM_STACK_TRACE32,
     EVENT_EXTENDED_ITEM_STACK_TRACE64,
 };

--- a/src/native/pla.rs
+++ b/src/native/pla.rs
@@ -6,7 +6,7 @@
 //! This module shouldn't be accessed directly. Modules from the the crate level provide a safe API to interact
 //! with the crate
 use std::mem::MaybeUninit;
-use windows::core::{GUID, BSTR};
+use windows::core::{BSTR, GUID};
 
 /// Pla native module errors
 #[derive(Debug, PartialEq, Eq)]
@@ -74,7 +74,7 @@ pub struct Variant {
 
 impl Variant {
     pub fn new(vt: u16, val: u32) -> Self {
-        Variant{
+        Variant {
             vt,
             val,
             ..Default::default()
@@ -149,7 +149,7 @@ pub(crate) unsafe fn get_provider_guid(name: &str) -> ProvidersComResult<GUID> {
 }
 
 mod pla_interfaces {
-    use super::{GUID, Variant, BSTR};
+    use super::{Variant, BSTR, GUID};
     use com::sys::IID;
     use com::{interfaces, interfaces::iunknown::IUnknown, sys::HRESULT};
 

--- a/src/native/sddl.rs
+++ b/src/native/sddl.rs
@@ -13,7 +13,7 @@ where
 {
     #[link(name = "kernel32")]
     extern "system" {
-        fn LocalFree(hmem : HLOCAL ) -> HLOCAL;
+        fn LocalFree(hmem: HLOCAL) -> HLOCAL;
     }
     let res = LocalFree(hmem.into_param().abi());
     match res.0 as usize {

--- a/src/native/time.rs
+++ b/src/native/time.rs
@@ -16,20 +16,21 @@ const MS_IN_SECOND: i64 = 1_000;
 impl FileTime {
     /// Converts to a unix timestamp with millisecond granularity.
     pub fn as_unix_timestamp(&self) -> i64 {
-        self.as_quad() / 10_000 - (SECONDS_BETWEEN_1601_AND_1970 * MS_IN_SECOND) 
+        self.as_quad() / 10_000 - (SECONDS_BETWEEN_1601_AND_1970 * MS_IN_SECOND)
     }
 
     /// Converts to a unix timestamp with nanosecond granularity.
     pub fn as_unix_timestamp_nanos(&self) -> i128 {
-        self.as_quad() as i128 * 100 - (SECONDS_BETWEEN_1601_AND_1970 as i128 * NS_IN_SECOND as i128)
+        self.as_quad() as i128 * 100
+            - (SECONDS_BETWEEN_1601_AND_1970 as i128 * NS_IN_SECOND as i128)
     }
-    
+
     /// Converts to OffsetDateTime
     #[cfg(feature = "time_rs")]
     pub fn as_date_time(&self) -> time::OffsetDateTime {
         time::OffsetDateTime::from_unix_timestamp_nanos(self.as_unix_timestamp_nanos()).unwrap()
     }
-    
+
     fn as_quad(&self) -> i64 {
         let mut quad = self.0.dwHighDateTime as i64;
         quad <<= 32;

--- a/src/native/version_helper.rs
+++ b/src/native/version_helper.rs
@@ -6,9 +6,11 @@
 //! At the moment the only option available is to check if the actual System Version is greater than
 //! Win8, is the only check we need for the crate to work as expected
 use windows::Win32::Foundation::GetLastError;
-use windows::Win32::System::SystemInformation::{OSVERSIONINFOEXA, VER_MAJORVERSION, VER_MINORVERSION, VER_SERVICEPACKMAJOR};
-use windows::Win32::System::SystemInformation::{VerifyVersionInfoA, VerSetConditionMask};
 use windows::Win32::Foundation::ERROR_OLD_WIN_VERSION;
+use windows::Win32::System::SystemInformation::{VerSetConditionMask, VerifyVersionInfoA};
+use windows::Win32::System::SystemInformation::{
+    OSVERSIONINFOEXA, VER_MAJORVERSION, VER_MINORVERSION, VER_SERVICEPACKMAJOR,
+};
 
 /// Version Helper native error
 #[derive(Debug)]
@@ -24,7 +26,7 @@ type OsVersionInfo = OSVERSIONINFOEXA;
 const VER_GREATER_OR_EQUAL: u8 = windows::Win32::System::SystemServices::VER_GREATER_EQUAL as u8;
 
 fn verify_system_version(major: u8, minor: u8, sp_major: u16) -> VersionHelperResult<bool> {
-    let mut os_version = OsVersionInfo{
+    let mut os_version = OsVersionInfo {
         dwOSVersionInfoSize: std::mem::size_of::<OsVersionInfo>() as u32,
         dwMajorVersion: major as u32,
         dwMinorVersion: minor as u32,
@@ -34,32 +36,21 @@ fn verify_system_version(major: u8, minor: u8, sp_major: u16) -> VersionHelperRe
 
     let mut condition_mask = 0;
     let res = unsafe {
-        condition_mask = VerSetConditionMask(
-            condition_mask,
-            VER_MAJORVERSION,
-            VER_GREATER_OR_EQUAL,
-        );
-        condition_mask = VerSetConditionMask(
-            condition_mask,
-            VER_MINORVERSION,
-            VER_GREATER_OR_EQUAL,
-        );
-        condition_mask = VerSetConditionMask(
-            condition_mask,
-            VER_SERVICEPACKMAJOR,
-            VER_GREATER_OR_EQUAL,
-        );
+        condition_mask =
+            VerSetConditionMask(condition_mask, VER_MAJORVERSION, VER_GREATER_OR_EQUAL);
+        condition_mask =
+            VerSetConditionMask(condition_mask, VER_MINORVERSION, VER_GREATER_OR_EQUAL);
+        condition_mask =
+            VerSetConditionMask(condition_mask, VER_SERVICEPACKMAJOR, VER_GREATER_OR_EQUAL);
 
         VerifyVersionInfoA(
             &mut os_version,
-            VER_MAJORVERSION
-                | VER_MINORVERSION
-                | VER_SERVICEPACKMAJOR,
+            VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR,
             condition_mask,
         )
     };
 
-    let error = unsafe{ GetLastError() };
+    let error = unsafe { GetLastError() };
 
     // See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-verifyversioninfoa#return-value
     match (res.is_ok(), error) {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -160,15 +160,15 @@ impl Provider {
 impl std::fmt::Debug for Provider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Provider")
-         .field("guid", &self.guid)
-         .field("any", &self.any)
-         .field("all", &self.all)
-         .field("level", &self.level)
-         .field("trace_flags", &self.trace_flags)
-         .field("kernel_flags", &self.kernel_flags)
-         .field("filters", &self.filters)
-         .field("callbacks", &self.callbacks.read().unwrap().len())
-         .finish()
+            .field("guid", &self.guid)
+            .field("any", &self.any)
+            .field("all", &self.all)
+            .field("level", &self.level)
+            .field("trace_flags", &self.trace_flags)
+            .field("kernel_flags", &self.kernel_flags)
+            .field("filters", &self.filters)
+            .field("callbacks", &self.callbacks.read().unwrap().len())
+            .finish()
     }
 }
 

--- a/src/provider/event_filter.rs
+++ b/src/provider/event_filter.rs
@@ -2,8 +2,13 @@ use std::alloc::Layout;
 use std::error::Error;
 
 use windows::Win32::Foundation::BOOLEAN;
-use windows::Win32::System::Diagnostics::Etw::{EVENT_FILTER_DESCRIPTOR, EVENT_FILTER_TYPE_PID, EVENT_FILTER_TYPE_EVENT_ID, EVENT_FILTER_EVENT_ID};
-use windows::Win32::System::Diagnostics::Etw::{MAX_EVENT_FILTER_EVENT_ID_COUNT, MAX_EVENT_FILTER_PID_COUNT};
+use windows::Win32::System::Diagnostics::Etw::{
+    EVENT_FILTER_DESCRIPTOR, EVENT_FILTER_EVENT_ID, EVENT_FILTER_TYPE_EVENT_ID,
+    EVENT_FILTER_TYPE_PID,
+};
+use windows::Win32::System::Diagnostics::Etw::{
+    MAX_EVENT_FILTER_EVENT_ID_COUNT, MAX_EVENT_FILTER_PID_COUNT,
+};
 
 /// Specifies how this provider will filter its events
 ///
@@ -52,8 +57,8 @@ impl EventFilterDescriptor {
             1..=1024 => data_size as u32,
             _ => {
                 // See https://docs.microsoft.com/en-us/windows/win32/api/evntprov/ns-evntprov-event_filter_descriptor
-                return Err("Exceeded filter size limits".into())
-            },
+                return Err("Exceeded filter size limits".into());
+            }
         };
 
         let layout = Layout::from_size_align(data_size as usize, std::mem::align_of::<T>())?;
@@ -64,7 +69,11 @@ impl EventFilterDescriptor {
         if data.is_null() {
             return Err("Invalid allocation".into());
         }
-        Ok(Self { data, layout, ty: 0 })
+        Ok(Self {
+            data,
+            layout,
+            ty: 0,
+        })
     }
 
     /// Build a new instance that will filter by event ID.
@@ -76,9 +85,8 @@ impl EventFilterDescriptor {
             return Err("Too many event IDs are filtered".into());
         }
 
-        let data_size = std::mem::size_of::<EVENT_FILTER_EVENT_ID>() + (
-            (eids.len().saturating_sub(1)) * std::mem::size_of::<u16>()
-        );
+        let data_size = std::mem::size_of::<EVENT_FILTER_EVENT_ID>()
+            + ((eids.len().saturating_sub(1)) * std::mem::size_of::<u16>());
         let mut s = Self::try_new::<EVENT_FILTER_EVENT_ID>(data_size)?;
         s.ty = EVENT_FILTER_TYPE_EVENT_ID;
 
@@ -126,7 +134,7 @@ impl EventFilterDescriptor {
         } else {
             let mut p = s.data.cast::<u16>();
             for pid in pids {
-                unsafe{
+                unsafe {
                     *p = *pid;
                 };
 
@@ -160,7 +168,7 @@ impl EventFilterDescriptor {
 
 impl Drop for EventFilterDescriptor {
     fn drop(&mut self) {
-        unsafe{
+        unsafe {
             // Safety:
             // * ptr is a block of memory currently allocated via alloc::alloc
             // * layout is th one that was used to allocate that block of memory

--- a/src/provider/kernel_providers.rs
+++ b/src/provider/kernel_providers.rs
@@ -14,51 +14,143 @@ use super::GUID;
 mod kernel_guids {
     use super::GUID;
     pub const ALPC_GUID: GUID = GUID::from_values(
-        0x45d8cccd, 0x539f, 0x4b72, [0xa8, 0xb7, 0x5c, 0x68, 0x31, 0x42, 0x60, 0x9a]);
+        0x45d8cccd,
+        0x539f,
+        0x4b72,
+        [0xa8, 0xb7, 0x5c, 0x68, 0x31, 0x42, 0x60, 0x9a],
+    );
     pub const POWER_GUID: GUID = GUID::from_values(
-        0xe43445e0, 0x0903, 0x48c3, [0xb8, 0x78, 0xff, 0x0f, 0xcc, 0xeb, 0xdd, 0x04]);
+        0xe43445e0,
+        0x0903,
+        0x48c3,
+        [0xb8, 0x78, 0xff, 0x0f, 0xcc, 0xeb, 0xdd, 0x04],
+    );
     pub const DEBUG_GUID: GUID = GUID::from_values(
-        0x13976d09, 0xa327, 0x438c, [0x95, 0x0b, 0x7f, 0x03, 0x19, 0x28, 0x15, 0xc7]);
+        0x13976d09,
+        0xa327,
+        0x438c,
+        [0x95, 0x0b, 0x7f, 0x03, 0x19, 0x28, 0x15, 0xc7],
+    );
     pub const TCP_IP_GUID: GUID = GUID::from_values(
-        0x9a280ac0, 0xc8e0, 0x11d1, [0x84, 0xe2, 0x00, 0xc0, 0x4f, 0xb9, 0x98, 0xa2]);
+        0x9a280ac0,
+        0xc8e0,
+        0x11d1,
+        [0x84, 0xe2, 0x00, 0xc0, 0x4f, 0xb9, 0x98, 0xa2],
+    );
     pub const UDP_IP_GUID: GUID = GUID::from_values(
-        0xbf3a50c5, 0xa9c9, 0x4988, [0xa0, 0x05, 0x2d, 0xf0, 0xb7, 0xc8, 0x0f, 0x80]);
+        0xbf3a50c5,
+        0xa9c9,
+        0x4988,
+        [0xa0, 0x05, 0x2d, 0xf0, 0xb7, 0xc8, 0x0f, 0x80],
+    );
     pub const THREAD_GUID: GUID = GUID::from_values(
-        0x3d6fa8d1, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+        0x3d6fa8d1,
+        0xfe05,
+        0x11d0,
+        [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+    );
     pub const DISK_IO_GUID: GUID = GUID::from_values(
-        0x3d6fa8d4, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+        0x3d6fa8d4,
+        0xfe05,
+        0x11d0,
+        [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+    );
     pub const FILE_IO_GUID: GUID = GUID::from_values(
-        0x90cbdc39, 0x4a3e, 0x11d1, [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3]);
+        0x90cbdc39,
+        0x4a3e,
+        0x11d1,
+        [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3],
+    );
     pub const PROCESS_GUID: GUID = GUID::from_values(
-        0x3d6fa8d0, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+        0x3d6fa8d0,
+        0xfe05,
+        0x11d0,
+        [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+    );
     pub const REGISTRY_GUID: GUID = GUID::from_values(
-        0xAE53722E, 0xC863, 0x11d2, [0x86, 0x59, 0x00, 0xC0, 0x4F, 0xA3, 0x21, 0xA1]);
+        0xAE53722E,
+        0xC863,
+        0x11d2,
+        [0x86, 0x59, 0x00, 0xC0, 0x4F, 0xA3, 0x21, 0xA1],
+    );
     pub const SPLIT_IO_GUID: GUID = GUID::from_values(
-        0xd837ca92, 0x12b9, 0x44a5, [0xad, 0x6a, 0x3a, 0x65, 0xb3, 0x57, 0x8a, 0xa8]);
+        0xd837ca92,
+        0x12b9,
+        0x44a5,
+        [0xad, 0x6a, 0x3a, 0x65, 0xb3, 0x57, 0x8a, 0xa8],
+    );
     pub const OB_TRACE_GUID: GUID = GUID::from_values(
-        0x89497f50, 0xeffe, 0x4440, [0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7]);
+        0x89497f50,
+        0xeffe,
+        0x4440,
+        [0x8c, 0xf2, 0xce, 0x6b, 0x1c, 0xdc, 0xac, 0xa7],
+    );
     pub const UMS_EVENT_GUID: GUID = GUID::from_values(
-        0x9aec974b, 0x5b8e, 0x4118, [0x9b, 0x92, 0x31, 0x86, 0xd8, 0x00, 0x2c, 0xe5]);
+        0x9aec974b,
+        0x5b8e,
+        0x4118,
+        [0x9b, 0x92, 0x31, 0x86, 0xd8, 0x00, 0x2c, 0xe5],
+    );
     pub const PERF_INFO_GUID: GUID = GUID::from_values(
-        0xce1dbfb4, 0x137e, 0x4da6, [0x87, 0xb0, 0x3f, 0x59, 0xaa, 0x10, 0x2c, 0xbc]);
+        0xce1dbfb4,
+        0x137e,
+        0x4da6,
+        [0x87, 0xb0, 0x3f, 0x59, 0xaa, 0x10, 0x2c, 0xbc],
+    );
     pub const PAGE_FAULT_GUID: GUID = GUID::from_values(
-        0x3d6fa8d3, 0xfe05, 0x11d0, [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c]);
+        0x3d6fa8d3,
+        0xfe05,
+        0x11d0,
+        [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
+    );
     pub const IMAGE_LOAD_GUID: GUID = GUID::from_values(
-        0x2cb15d1d, 0x5fc1, 0x11d2, [0xab, 0xe1, 0x00, 0xa0, 0xc9, 0x11, 0xf5, 0x18]);
+        0x2cb15d1d,
+        0x5fc1,
+        0x11d2,
+        [0xab, 0xe1, 0x00, 0xa0, 0xc9, 0x11, 0xf5, 0x18],
+    );
     pub const POOL_TRACE_GUID: GUID = GUID::from_values(
-        0x0268a8b6, 0x74fd, 0x4302, [0x9d, 0xd0, 0x6e, 0x8f, 0x17, 0x95, 0xc0, 0xcf]);
+        0x0268a8b6,
+        0x74fd,
+        0x4302,
+        [0x9d, 0xd0, 0x6e, 0x8f, 0x17, 0x95, 0xc0, 0xcf],
+    );
     pub const LOST_EVENT_GUID: GUID = GUID::from_values(
-        0x6a399ae0, 0x4bc6, 0x4de9, [0x87, 0x0b, 0x36, 0x57, 0xf8, 0x94, 0x7e, 0x7e]);
+        0x6a399ae0,
+        0x4bc6,
+        0x4de9,
+        [0x87, 0x0b, 0x36, 0x57, 0xf8, 0x94, 0x7e, 0x7e],
+    );
     pub const STACK_WALK_GUID: GUID = GUID::from_values(
-        0xdef2fe46, 0x7bd6, 0x4b80, [0xbd, 0x94, 0xf5, 0x7f, 0xe2, 0x0d, 0x0c, 0xe3]);
+        0xdef2fe46,
+        0x7bd6,
+        0x4b80,
+        [0xbd, 0x94, 0xf5, 0x7f, 0xe2, 0x0d, 0x0c, 0xe3],
+    );
     pub const EVENT_TRACE_GUID: GUID = GUID::from_values(
-        0x68fdd900, 0x4a3e, 0x11d1, [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3]);
+        0x68fdd900,
+        0x4a3e,
+        0x11d1,
+        [0x84, 0xf4, 0x00, 0x00, 0xf8, 0x04, 0x64, 0xe3],
+    );
     pub const MMCSS_TRACE_GUID: GUID = GUID::from_values(
-        0xf8f10121, 0xb617, 0x4a56, [0x86, 0x8b, 0x9d, 0xf1, 0xb2, 0x7f, 0xe3, 0x2c]);
+        0xf8f10121,
+        0xb617,
+        0x4a56,
+        [0x86, 0x8b, 0x9d, 0xf1, 0xb2, 0x7f, 0xe3, 0x2c],
+    );
     pub const SYSTEM_TRACE_GUID: GUID = GUID::from_values(
-        0x9e814aad, 0x3204, 0x11d2, [0x9a, 0x82, 0x00, 0x60, 0x08, 0xa8, 0x69, 0x39]);
+        0x9e814aad,
+        0x3204,
+        0x11d2,
+        [0x9a, 0x82, 0x00, 0x60, 0x08, 0xa8, 0x69, 0x39],
+    );
     pub const EVENT_TRACE_CONFIG_GUID: GUID = GUID::from_values(
-        0x01853a65, 0x418f, 0x4f36, [0xae, 0xfc, 0xdc, 0x0f, 0x1d, 0x2f, 0xd2, 0x35]);
+        0x01853a65,
+        0x418f,
+        0x4f36,
+        [0xae, 0xfc, 0xdc, 0x0f, 0x1d, 0x2f, 0xd2, 0x35],
+    );
 }
 
 /// List of Kernel Providers flags
@@ -106,128 +198,133 @@ pub struct KernelProvider {
 impl KernelProvider {
     /// Use the `new` function to create a Kernel Provider which can be then tied into a Provider
     pub const fn new(guid: GUID, flags: u32) -> KernelProvider {
-        KernelProvider {
-            guid,
-            flags,
-        }
+        KernelProvider { guid, flags }
     }
 }
 
 /// Represents the VirtualAlloc Kernel Provider
 pub static VIRTUAL_ALLOC_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PAGE_FAULT_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_VIRTUAL_ALLOC
+    kernel_flags::EVENT_TRACE_FLAG_VIRTUAL_ALLOC,
 );
 /// Represents the VA Map Kernel Provider
-pub static VAMAP_PROVIDER: KernelProvider =
-    KernelProvider::new(kernel_guids::FILE_IO_GUID, kernel_flags::EVENT_TRACE_FLAG_VAMAP);
+pub static VAMAP_PROVIDER: KernelProvider = KernelProvider::new(
+    kernel_guids::FILE_IO_GUID,
+    kernel_flags::EVENT_TRACE_FLAG_VAMAP,
+);
 /// Represents the Thread Kernel Provider
-pub static THREAD_PROVIDER: KernelProvider =
-    KernelProvider::new(kernel_guids::THREAD_GUID, kernel_flags::EVENT_TRACE_FLAG_THREAD);
+pub static THREAD_PROVIDER: KernelProvider = KernelProvider::new(
+    kernel_guids::THREAD_GUID,
+    kernel_flags::EVENT_TRACE_FLAG_THREAD,
+);
 /// Represents the Split IO Kernel Provider
 pub static SPLIT_IO_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::SPLIT_IO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_SPLIT_IO
+    kernel_flags::EVENT_TRACE_FLAG_SPLIT_IO,
 );
 /// Represents the SystemCall Kernel Provider
 pub static SYSTEM_CALL_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PERF_INFO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_SYSTEMCALL
+    kernel_flags::EVENT_TRACE_FLAG_SYSTEMCALL,
 );
 /// Represents the Registry Kernel Provider
 pub static REGISTRY_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::REGISTRY_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_REGISTRY
+    kernel_flags::EVENT_TRACE_FLAG_REGISTRY,
 );
 /// Represents the Profile Kernel Provider
 pub static PROFILE_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PERF_INFO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_PROFILE
+    kernel_flags::EVENT_TRACE_FLAG_PROFILE,
 );
 /// Represents the Process Counter Kernel Provider
 pub static PROCESS_COUNTER_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PROCESS_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_PROCESS_COUNTERS
+    kernel_flags::EVENT_TRACE_FLAG_PROCESS_COUNTERS,
 );
 /// Represents the Process Kernel Provider
 pub static PROCESS_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PROCESS_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_PROCESS
+    kernel_flags::EVENT_TRACE_FLAG_PROCESS,
 );
 /// Represents the TCP-IP Kernel Provider
 pub static TCP_IP_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::TCP_IP_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_NETWORK_TCPIP
+    kernel_flags::EVENT_TRACE_FLAG_NETWORK_TCPIP,
 );
 /// Represents the Memory Page Fault Kernel Provider
 pub static MEMORY_PAGE_FAULT_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PAGE_FAULT_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_MEMORY_PAGE_FAULTS
+    kernel_flags::EVENT_TRACE_FLAG_MEMORY_PAGE_FAULTS,
 );
 /// Represents the Memory Hard Fault Kernel Provider
 pub static MEMORY_HARD_FAULT_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PAGE_FAULT_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_MEMORY_HARD_FAULTS
+    kernel_flags::EVENT_TRACE_FLAG_MEMORY_HARD_FAULTS,
 );
 /// Represents the Interrupt Kernel Provider
 pub static INTERRUPT_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::PERF_INFO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_INTERRUPT
+    kernel_flags::EVENT_TRACE_FLAG_INTERRUPT,
 );
 /// Represents the Driver Kernel Provider
 pub static DRIVER_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::DISK_IO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_DISK_IO
+    kernel_flags::EVENT_TRACE_FLAG_DISK_IO,
 );
 /// Represents the DPC Kernel Provider
-pub static DPC_PROVIDER: KernelProvider =
-    KernelProvider::new(kernel_guids::PERF_INFO_GUID, kernel_flags::EVENT_TRACE_FLAG_DPC);
+pub static DPC_PROVIDER: KernelProvider = KernelProvider::new(
+    kernel_guids::PERF_INFO_GUID,
+    kernel_flags::EVENT_TRACE_FLAG_DPC,
+);
 /// Represents the Image Load Kernel Provider
 pub static IMAGE_LOAD_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::IMAGE_LOAD_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_IMAGE_LOAD
+    kernel_flags::EVENT_TRACE_FLAG_IMAGE_LOAD,
 );
 /// Represents the Thread Dispatcher Kernel Provider
 pub static THREAD_DISPATCHER_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::THREAD_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_DISPATCHER
+    kernel_flags::EVENT_TRACE_FLAG_DISPATCHER,
 );
 /// Represents the File Init IO Kernel Provider
 pub static FILE_INIT_IO_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::FILE_IO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_FILE_IO_INIT
+    kernel_flags::EVENT_TRACE_FLAG_FILE_IO_INIT,
 );
 /// Represents the File IO Kernel Provider
 pub static FILE_IO_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::FILE_IO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_FILE_IO
+    kernel_flags::EVENT_TRACE_FLAG_FILE_IO,
 );
 /// Represents the Disk IO Init Kernel Provider
 pub static DISK_IO_INIT_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::DISK_IO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_DISK_IO_INIT
+    kernel_flags::EVENT_TRACE_FLAG_DISK_IO_INIT,
 );
 /// Represents the Disk IO Kernel Provider
 pub static DISK_IO_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::DISK_IO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_DISK_IO
+    kernel_flags::EVENT_TRACE_FLAG_DISK_IO,
 );
 /// Represents the Disk File IO Kernel Provider
 pub static DISK_FILE_IO_PROVIDER: KernelProvider = KernelProvider::new(
     kernel_guids::DISK_IO_GUID,
-    kernel_flags::EVENT_TRACE_FLAG_DISK_FILE_IO
+    kernel_flags::EVENT_TRACE_FLAG_DISK_FILE_IO,
 );
 /// Represents the Dbg Pring Kernel Provider
-pub static DEBUG_PRINT_PROVIDER: KernelProvider =
-    KernelProvider::new(kernel_guids::DEBUG_GUID, kernel_flags::EVENT_TRACE_FLAG_DBGPRINT);
+pub static DEBUG_PRINT_PROVIDER: KernelProvider = KernelProvider::new(
+    kernel_guids::DEBUG_GUID,
+    kernel_flags::EVENT_TRACE_FLAG_DBGPRINT,
+);
 /// Represents the Context Swtich Kernel Provider
-pub static CONTEXT_SWITCH_PROVIDER: KernelProvider =
-    KernelProvider::new(kernel_guids::THREAD_GUID, kernel_flags::EVENT_TRACE_FLAG_CSWITCH);
+pub static CONTEXT_SWITCH_PROVIDER: KernelProvider = KernelProvider::new(
+    kernel_guids::THREAD_GUID,
+    kernel_flags::EVENT_TRACE_FLAG_CSWITCH,
+);
 /// Represents the ALPC Kernel Provider
 pub static ALPC_PROVIDER: KernelProvider =
     KernelProvider::new(kernel_guids::ALPC_GUID, kernel_flags::EVENT_TRACE_FLAG_ALPC);
-
-
 
 #[cfg(test)]
 mod test {
@@ -239,7 +336,8 @@ mod test {
 
     #[test]
     fn test_kernel_provider_struct() {
-        let kernel_provider = KernelProvider::new("D396B546-287D-4712-A7F5-8BE226A8C643".into(), 0x10000);
+        let kernel_provider =
+            KernelProvider::new("D396B546-287D-4712-A7F5-8BE226A8C643".into(), 0x10000);
 
         assert_eq!(0x10000, kernel_provider.flags);
         assert_eq!(
@@ -258,28 +356,97 @@ mod test {
 
     #[test]
     fn test_kernel_provider_guids_correct() {
-        assert_eq!(ALPC_GUID, GUID::from("45d8cccd-539f-4b72-a8b7-5c683142609a"));
-        assert_eq!(POWER_GUID, GUID::from("e43445e0-0903-48c3-b878-ff0fccebdd04"));
-        assert_eq!(DEBUG_GUID, GUID::from("13976d09-a327-438c-950b-7f03192815c7"));
-        assert_eq!(TCP_IP_GUID, GUID::from("9a280ac0-c8e0-11d1-84e2-00c04fb998a2"));
-        assert_eq!(UDP_IP_GUID, GUID::from("bf3a50c5-a9c9-4988-a005-2df0b7c80f80"));
-        assert_eq!(THREAD_GUID, GUID::from("3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(DISK_IO_GUID, GUID::from("3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(FILE_IO_GUID, GUID::from("90cbdc39-4a3e-11d1-84f4-0000f80464e3"));
-        assert_eq!(PROCESS_GUID, GUID::from("3d6fa8d0-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(REGISTRY_GUID, GUID::from("AE53722E-C863-11d2-8659-00C04FA321A1"));
-        assert_eq!(SPLIT_IO_GUID, GUID::from("d837ca92-12b9-44a5-ad6a-3a65b3578aa8"));
-        assert_eq!(OB_TRACE_GUID, GUID::from("89497f50-effe-4440-8cf2-ce6b1cdcaca7"));
-        assert_eq!(UMS_EVENT_GUID, GUID::from("9aec974b-5b8e-4118-9b92-3186d8002ce5"));
-        assert_eq!(PERF_INFO_GUID, GUID::from("ce1dbfb4-137e-4da6-87b0-3f59aa102cbc"));
-        assert_eq!(PAGE_FAULT_GUID, GUID::from("3d6fa8d3-fe05-11d0-9dda-00c04fd7ba7c"));
-        assert_eq!(IMAGE_LOAD_GUID, GUID::from("2cb15d1d-5fc1-11d2-abe1-00a0c911f518"));
-        assert_eq!(POOL_TRACE_GUID, GUID::from("0268a8b6-74fd-4302-9dd0-6e8f1795c0cf"));
-        assert_eq!(LOST_EVENT_GUID, GUID::from("6a399ae0-4bc6-4de9-870b-3657f8947e7e"));
-        assert_eq!(STACK_WALK_GUID, GUID::from("def2fe46-7bd6-4b80-bd94-f57fe20d0ce3"));
-        assert_eq!(EVENT_TRACE_GUID, GUID::from("68fdd900-4a3e-11d1-84f4-0000f80464e3"));
-        assert_eq!(MMCSS_TRACE_GUID, GUID::from("f8f10121-b617-4a56-868b-9df1b27fe32c"));
-        assert_eq!(SYSTEM_TRACE_GUID, GUID::from("9e814aad-3204-11d2-9a82-006008a86939"));
-        assert_eq!(EVENT_TRACE_CONFIG_GUID, GUID::from("01853a65-418f-4f36-aefc-dc0f1d2fd235"));
+        assert_eq!(
+            ALPC_GUID,
+            GUID::from("45d8cccd-539f-4b72-a8b7-5c683142609a")
+        );
+        assert_eq!(
+            POWER_GUID,
+            GUID::from("e43445e0-0903-48c3-b878-ff0fccebdd04")
+        );
+        assert_eq!(
+            DEBUG_GUID,
+            GUID::from("13976d09-a327-438c-950b-7f03192815c7")
+        );
+        assert_eq!(
+            TCP_IP_GUID,
+            GUID::from("9a280ac0-c8e0-11d1-84e2-00c04fb998a2")
+        );
+        assert_eq!(
+            UDP_IP_GUID,
+            GUID::from("bf3a50c5-a9c9-4988-a005-2df0b7c80f80")
+        );
+        assert_eq!(
+            THREAD_GUID,
+            GUID::from("3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            DISK_IO_GUID,
+            GUID::from("3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            FILE_IO_GUID,
+            GUID::from("90cbdc39-4a3e-11d1-84f4-0000f80464e3")
+        );
+        assert_eq!(
+            PROCESS_GUID,
+            GUID::from("3d6fa8d0-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            REGISTRY_GUID,
+            GUID::from("AE53722E-C863-11d2-8659-00C04FA321A1")
+        );
+        assert_eq!(
+            SPLIT_IO_GUID,
+            GUID::from("d837ca92-12b9-44a5-ad6a-3a65b3578aa8")
+        );
+        assert_eq!(
+            OB_TRACE_GUID,
+            GUID::from("89497f50-effe-4440-8cf2-ce6b1cdcaca7")
+        );
+        assert_eq!(
+            UMS_EVENT_GUID,
+            GUID::from("9aec974b-5b8e-4118-9b92-3186d8002ce5")
+        );
+        assert_eq!(
+            PERF_INFO_GUID,
+            GUID::from("ce1dbfb4-137e-4da6-87b0-3f59aa102cbc")
+        );
+        assert_eq!(
+            PAGE_FAULT_GUID,
+            GUID::from("3d6fa8d3-fe05-11d0-9dda-00c04fd7ba7c")
+        );
+        assert_eq!(
+            IMAGE_LOAD_GUID,
+            GUID::from("2cb15d1d-5fc1-11d2-abe1-00a0c911f518")
+        );
+        assert_eq!(
+            POOL_TRACE_GUID,
+            GUID::from("0268a8b6-74fd-4302-9dd0-6e8f1795c0cf")
+        );
+        assert_eq!(
+            LOST_EVENT_GUID,
+            GUID::from("6a399ae0-4bc6-4de9-870b-3657f8947e7e")
+        );
+        assert_eq!(
+            STACK_WALK_GUID,
+            GUID::from("def2fe46-7bd6-4b80-bd94-f57fe20d0ce3")
+        );
+        assert_eq!(
+            EVENT_TRACE_GUID,
+            GUID::from("68fdd900-4a3e-11d1-84f4-0000f80464e3")
+        );
+        assert_eq!(
+            MMCSS_TRACE_GUID,
+            GUID::from("f8f10121-b617-4a56-868b-9df1b27fe32c")
+        );
+        assert_eq!(
+            SYSTEM_TRACE_GUID,
+            GUID::from("9e814aad-3204-11d2-9a82-006008a86939")
+        );
+        assert_eq!(
+            EVENT_TRACE_CONFIG_GUID,
+            GUID::from("01853a65-418f-4f36-aefc-dc0f1d2fd235")
+        );
     }
 }

--- a/src/schema_locator.rs
+++ b/src/schema_locator.rs
@@ -5,9 +5,9 @@ use std::sync::{Arc, Mutex};
 
 use windows::core::GUID;
 
+use crate::native::etw_types::event_record::EventRecord;
 use crate::native::tdh;
 use crate::native::tdh::TraceEventInfo;
-use crate::native::etw_types::event_record::EventRecord;
 use crate::schema::Schema;
 
 /// Schema module errors

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -406,7 +406,9 @@ impl PropSerable for PropertyInfo {
     fn get_parser(&self) -> Option<PropSer> {
         // give the output type parser first if there is one, otherwise use the input type
         match self {
-            PropertyInfo::Value { in_type, out_type, .. } => {
+            PropertyInfo::Value {
+                in_type, out_type, ..
+            } => {
                 match out_type {
                     TdhOutType::OutTypeIpv4 => Some(PropSer(PropHandler::IpAddr)),
                     TdhOutType::OutTypeIpv6 => Some(PropSer(PropHandler::IpAddr)),

--- a/src/trace/callback_data.rs
+++ b/src/trace/callback_data.rs
@@ -3,10 +3,10 @@ use std::sync::RwLock;
 
 use windows::Win32::System::Diagnostics::Etw;
 
-use crate::trace::RealTimeTraceTrait;
 use crate::native::etw_types::event_record::EventRecord;
 use crate::provider::Provider;
 use crate::schema_locator::SchemaLocator;
+use crate::trace::RealTimeTraceTrait;
 use crate::EtwCallback;
 
 pub use crate::native::etw_types::LoggingMode;
@@ -95,7 +95,6 @@ impl RealTimeCallbackData {
         }
     }
 }
-
 
 impl CallbackDataFromFile {
     pub fn new(callback: EtwCallback) -> Self {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,5 @@
 use std::iter;
 
-
 pub trait EncodeUtf16 {
     fn into_utf16(self) -> Vec<u16>;
 }

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -1,15 +1,15 @@
 //! Use the DNS provider to test a few things regarding user traces
 
-use std::time::Duration;
 use std::process::Command;
+use std::time::Duration;
 
-use ferrisetw::provider::{Provider, EventFilter};
-use ferrisetw::EventRecord;
-use ferrisetw::schema_locator::SchemaLocator;
-use ferrisetw::trace::UserTrace;
-use ferrisetw::trace::TraceTrait;
 use ferrisetw::parser::Parser;
+use ferrisetw::provider::{EventFilter, Provider};
 use ferrisetw::schema::Schema;
+use ferrisetw::schema_locator::SchemaLocator;
+use ferrisetw::trace::TraceTrait;
+use ferrisetw::trace::UserTrace;
+use ferrisetw::EventRecord;
 
 mod utils;
 use utils::{Status, TestKind};
@@ -18,8 +18,6 @@ const TEST_DOMAIN_NAME: &str = "www.github.com";
 
 const EVENT_ID_DNS_QUERY_INITIATED: u16 = 3006;
 const EVENT_ID_DNS_QUERY_COMPLETED: u16 = 3008;
-
-
 
 #[test]
 fn dns_tests() {
@@ -32,19 +30,20 @@ fn simple_user_dns_trace() {
     let passed = Status::new(TestKind::ExpectSuccess);
     let notifier = passed.notifier();
 
-    let dns_provider = Provider
-        ::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
-        .add_callback(move |record: &EventRecord, schema_locator: &SchemaLocator| {
-            let schema = schema_locator.event_schema(record).unwrap();
-            let parser = Parser::create(record, &schema);
+    let dns_provider = Provider::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
+        .add_callback(
+            move |record: &EventRecord, schema_locator: &SchemaLocator| {
+                let schema = schema_locator.event_schema(record).unwrap();
+                let parser = Parser::create(record, &schema);
 
-            // While we're at it, let's check a few more-or-less unrelated things on an actual ETW event
-            check_a_few_cases(record, &parser, &schema);
+                // While we're at it, let's check a few more-or-less unrelated things on an actual ETW event
+                check_a_few_cases(record, &parser, &schema);
 
-            if has_seen_resolution_to_test_domain(record, &parser) {
-                notifier.notify_success();
-            }
-        })
+                if has_seen_resolution_to_test_domain(record, &parser) {
+                    notifier.notify_success();
+                }
+            },
+        )
         .build();
 
     let dns_trace = UserTrace::new()
@@ -71,23 +70,26 @@ fn test_event_id_filter() {
 
     let filter = EventFilter::ByEventIds(vec![EVENT_ID_DNS_QUERY_COMPLETED]);
 
-    let dns_provider = Provider
-        ::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
+    let dns_provider = Provider::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
         .add_filter(filter)
-        .add_callback(move |record: &EventRecord, _schema_locator: &SchemaLocator| {
-            // We want at least one event, but only for the filtered kind
-            if record.event_id() == EVENT_ID_DNS_QUERY_COMPLETED {
-                notifier1.notify_success();
-            } else {
-                notifier2.notify_failure();
-            }
-        })
-        .add_callback(move |record: &EventRecord, _schema_locator: &SchemaLocator| {
-            // This secondary callback basically tests all callbacks are run
-            if record.event_id() == EVENT_ID_DNS_QUERY_COMPLETED {
-                notifier3.notify_success();
-            }
-        })
+        .add_callback(
+            move |record: &EventRecord, _schema_locator: &SchemaLocator| {
+                // We want at least one event, but only for the filtered kind
+                if record.event_id() == EVENT_ID_DNS_QUERY_COMPLETED {
+                    notifier1.notify_success();
+                } else {
+                    notifier2.notify_failure();
+                }
+            },
+        )
+        .add_callback(
+            move |record: &EventRecord, _schema_locator: &SchemaLocator| {
+                // This secondary callback basically tests all callbacks are run
+                if record.event_id() == EVENT_ID_DNS_QUERY_COMPLETED {
+                    notifier3.notify_success();
+                }
+            },
+        )
         .build();
 
     let _trace = UserTrace::new()
@@ -105,18 +107,17 @@ fn test_event_id_filter() {
     println!("test_event_id_filter passed");
 }
 
-
 fn generate_dns_events() {
     std::thread::sleep(Duration::from_secs(1));
     // Unfortunately, `&str::to_socket_addrs()` does not use Microsoft APIs, and hence does not trigger a DNS ETW event
     // Let's use ping.exe instead
     println!("Resolving {}...", TEST_DOMAIN_NAME);
     let _output = Command::new("ping.exe")
-       .arg("-n")
-       .arg("1")
-       .arg(TEST_DOMAIN_NAME)
-       .output()
-       .unwrap();
+        .arg("-n")
+        .arg("1")
+        .arg(TEST_DOMAIN_NAME)
+        .output()
+        .unwrap();
     println!("Resolution done.");
 }
 

--- a/tests/file_trace.rs
+++ b/tests/file_trace.rs
@@ -1,18 +1,18 @@
-use std::time::Duration;
 use std::path::PathBuf;
+use std::time::Duration;
 
-use ferrisetw::EventRecord;
-use ferrisetw::{UserTrace, FileTrace};
 use ferrisetw::provider::Provider;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::DumpFileParams;
 use ferrisetw::trace::TraceTrait;
+use ferrisetw::EventRecord;
+use ferrisetw::{FileTrace, UserTrace};
 
 #[test]
 fn etl_file() {
     env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
 
-    let dump_file = DumpFileParams{
+    let dump_file = DumpFileParams {
         file_path: PathBuf::from("etw-dump-file.etl"),
         ..Default::default()
     };
@@ -26,8 +26,7 @@ fn etl_file() {
 fn empty_callback(_record: &EventRecord, _schema_locator: &SchemaLocator) {}
 
 fn save_a_trace(dump_file: DumpFileParams) -> usize {
-    let process_provider = Provider
-        ::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
+    let process_provider = Provider::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
         .add_callback(empty_callback)
         .build();
 
@@ -46,9 +45,7 @@ fn save_a_trace(dump_file: DumpFileParams) -> usize {
 }
 
 fn process_from_file(input_file: PathBuf) -> usize {
-    let (trace, handle) = FileTrace::new(input_file, empty_callback)
-        .start()
-        .unwrap();
+    let (trace, handle) = FileTrace::new(input_file, empty_callback).start().unwrap();
 
     FileTrace::process_from_handle(handle).unwrap();
 

--- a/tests/kernel_trace.rs
+++ b/tests/kernel_trace.rs
@@ -2,24 +2,21 @@
 
 use std::time::Duration;
 
-use ferrisetw::provider::{Provider, EventFilter};
-use ferrisetw::EventRecord;
-use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::parser::Parser;
-use ferrisetw::trace::KernelTrace;
 use ferrisetw::provider::kernel_providers;
+use ferrisetw::provider::{EventFilter, Provider};
+use ferrisetw::schema_locator::SchemaLocator;
+use ferrisetw::trace::KernelTrace;
+use ferrisetw::EventRecord;
 
-use windows::Win32::Foundation::HANDLE;
 use windows::core::HSTRING;
-use windows::Win32::System::LibraryLoader::{LOAD_LIBRARY_FLAGS, LoadLibraryExW};
-
+use windows::Win32::Foundation::HANDLE;
+use windows::Win32::System::LibraryLoader::{LoadLibraryExW, LOAD_LIBRARY_FLAGS};
 
 mod utils;
-use utils::{Status, TestKind, StatusNotifier};
+use utils::{Status, StatusNotifier, TestKind};
 
 const TEST_LIBRARY_NAME: &str = "crypt32.dll"; // this DLL is available on all Windows versions (so that the test can run everywhere)
-
-
 
 #[test]
 fn kernel_trace_tests() {
@@ -43,20 +40,21 @@ fn create_simple_kernel_trace_trace(notifier: StatusNotifier) -> KernelTrace {
 
     let kernel_provider = Provider::kernel(&kernel_providers::IMAGE_LOAD_PROVIDER)
         .add_filter(our_process_only)
-        .add_callback(move |record: &EventRecord, schema_locator: &SchemaLocator| {
-            let schema = schema_locator.event_schema(record).unwrap();
-            let parser = Parser::create(record, &schema);
+        .add_callback(
+            move |record: &EventRecord, schema_locator: &SchemaLocator| {
+                let schema = schema_locator.event_schema(record).unwrap();
+                let parser = Parser::create(record, &schema);
 
-            // By-PID filters are not working (yet?)
-            // See See https://github.com/n4r1b/ferrisetw/issues/51
-            // if has_seen_other_pid(record) {
-            //     notifier2.notify_failure();
-            // }
-            if has_seen_dll_load(record, &parser) {
-                notifier.notify_success();
-            }
-
-        })
+                // By-PID filters are not working (yet?)
+                // See See https://github.com/n4r1b/ferrisetw/issues/51
+                // if has_seen_other_pid(record) {
+                //     notifier2.notify_failure();
+                // }
+                if has_seen_dll_load(record, &parser) {
+                    notifier.notify_success();
+                }
+            },
+        )
         .build();
 
     KernelTrace::new()
@@ -69,13 +67,8 @@ fn load_library(libname: &str) {
     let widename = HSTRING::from(libname);
 
     // Safety: LoadLibraryExW expects a valid string in lpLibFileName.
-    let res = unsafe {
-            LoadLibraryExW(
-            &widename,
-            HANDLE::default(),
-            LOAD_LIBRARY_FLAGS::default(),
-        )
-    };
+    let res =
+        unsafe { LoadLibraryExW(&widename, HANDLE::default(), LOAD_LIBRARY_FLAGS::default()) };
 
     res.unwrap();
 }
@@ -86,8 +79,6 @@ fn generate_image_load_events() {
     load_library(TEST_LIBRARY_NAME);
     println!("Loading done.");
 }
-
-
 
 fn has_seen_dll_load(record: &EventRecord, parser: &Parser) -> bool {
     if record.process_id() == std::process::id() {
@@ -102,4 +93,3 @@ fn has_seen_dll_load(record: &EventRecord, parser: &Parser) -> bool {
 
     false
 }
-

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -186,10 +186,7 @@ fn do_benchmark(
         .expect("thread panic")
         .expect("trace processing error");
 
-    println!(
-        "{:<32}: {} b {} s {} e",
-        name, last_b, last_s, last_e
-    );
+    println!("{:<32}: {} b {} s {} e", name, last_b, last_s, last_e);
     assert_eq!(last_e, 0, "encountered errors when benchmarking");
 }
 


### PR DESCRIPTION
Avoid any future arguments about formatting by just enforcing Cargo's built-in formatting :)