### PR TITLE
deps: zerocopy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ num-traits = "0.2"
 num-derive = "0.4"
 bitflags = "1.3.2"
 widestring = "1.0"
-zerocopy = "0.6"
+zerocopy = "0.7"
 time = { version = "0.3", features = ["large-dates"], optional = true }
 serde = { version = "1.0", optional = true }
 # thiserror = "~1.0"


### PR DESCRIPTION
I see the dependabot MR was closed, was there a reason ?