### PR TITLE
Fixing property parsing issue on Rust 1.78+

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -471,7 +471,7 @@ impl private::TryParse<String> for Parser<'_, '_> {
                     }
 
                     if prop_slice.buffer.as_ptr() as usize % align != 0 {
-                        println!("[ferrisetw] buffer alignment mismatch");
+                        println!("[ferrisetw] buffer alignment mismatch. align: {} size: {}", align, prop_slice.buffer.as_ptr() as usize);
                         return Err(ParserError::PropertyError(
                             "buffer alignment mismatch".into(),
                         ));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -375,18 +375,21 @@ macro_rules! impl_try_parse_primitive_array {
                         let align = std::mem::align_of::<$T>();
 
                         if prop_slice.buffer.len() % size != 0 {
+                            println!("[ferrisetw] length mismatch");
                             return Err(ParserError::LengthMismatch);
                         }
 
                         let count = prop_slice.buffer.len() / size;
 
                         if prop_slice.buffer.as_ptr() as usize % align != 0 {
+                            println!("[ferrisetw] buffer alignment mismatch");
                             return Err(ParserError::PropertyError(
                                 "buffer alignment mismatch".into()
                             ));
                         }
 
                         if size.checked_mul(count).is_none() || (size * count) > isize::MAX as usize {
+                            println!("[ferrisetw] size overflow");
                             return Err(ParserError::PropertyError(
                                 "size overflow".into()
                             ));
@@ -461,12 +464,14 @@ impl private::TryParse<String> for Parser<'_, '_> {
                     let align = std::mem::align_of::<u16>();
 
                     if prop_slice.buffer.len() % 2 != 0 {
+                        println!("[ferrisetw] odd length in bytes for a wide string");
                         return Err(ParserError::PropertyError(
                             "odd length in bytes for a wide string".into(),
                         ));
                     }
 
                     if prop_slice.buffer.as_ptr() as usize % align != 0 {
+                        println!("[ferrisetw] buffer alignment mismatch");
                         return Err(ParserError::PropertyError(
                             "buffer alignment mismatch".into(),
                         ));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -461,7 +461,7 @@ impl private::TryParse<String> for Parser<'_, '_> {
         match prop_slice.property.info {
             PropertyInfo::Value { in_type, .. } => match in_type {
                 TdhInType::InTypeUnicodeString => {
-                    let align = std::mem::align_of::<u16>();
+                    //let align = std::mem::align_of::<u16>();
 
                     if prop_slice.buffer.len() % 2 != 0 {
                         println!("[ferrisetw] odd length in bytes for a wide string");
@@ -470,12 +470,12 @@ impl private::TryParse<String> for Parser<'_, '_> {
                         ));
                     }
 
-                    if prop_slice.buffer.as_ptr() as usize % align != 0 {
-                        println!("[ferrisetw] buffer alignment mismatch. align: {} size: {}", align, prop_slice.buffer.as_ptr() as usize);
-                        return Err(ParserError::PropertyError(
-                            "buffer alignment mismatch".into(),
-                        ));
-                    }
+                    // if prop_slice.buffer.as_ptr() as usize % align != 0 {
+                    //     println!("[ferrisetw] buffer alignment mismatch. align: {} size: {}", align, prop_slice.buffer.as_ptr() as usize);
+                    //     return Err(ParserError::PropertyError(
+                    //         "buffer alignment mismatch".into(),
+                    //     ));
+                    // }
 
                     let mut wide = unsafe {
                         std::slice::from_raw_parts(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -470,6 +470,14 @@ impl private::TryParse<String> for Parser<'_, '_> {
                         ));
                     }
 
+                    let mut aligned_buffer = Vec::with_capacity(prop_slice.buffer.len() / 2);
+                    for chunk in prop_slice.buffer.chunks_exact(2) {
+                        let part = u16::from_ne_bytes([chunk[0], chunk[1]]);
+                        aligned_buffer.push(part);
+                    }
+
+
+
                     // if prop_slice.buffer.as_ptr() as usize % align != 0 {
                     //     println!("[ferrisetw] buffer alignment mismatch. align: {} size: {}", align, prop_slice.buffer.as_ptr() as usize);
                     //     return Err(ParserError::PropertyError(
@@ -477,12 +485,14 @@ impl private::TryParse<String> for Parser<'_, '_> {
                     //     ));
                     // }
 
-                    let mut wide = unsafe {
-                        std::slice::from_raw_parts(
-                            prop_slice.buffer.as_ptr() as *const u16,
-                            prop_slice.buffer.len() / 2,
-                        )
-                    };
+                    // let mut wide = unsafe {
+                    //     std::slice::from_raw_parts(
+                    //         prop_slice.buffer.as_ptr() as *const u16,
+                    //         prop_slice.buffer.len() / 2,
+                    //     )
+                    // };
+
+                    let mut wide = aligned_buffer.as_slice();
 
                     match wide.last() {
                         // remove the null terminator from the slice


### PR DESCRIPTION
Rust introduced a change to `std::slice::from_raw_parts()` that breaks this crate. The panics caused by this change occur when parsing properties with the most prevalent being those of type `TDH_INTYPE_UNICODESTRING` in my testing. 

To resolve this issue, this MR adds checks to validate the assertions made in `std::slice::from_raw_parts()` . These are:
1. the pointer must not be NULL
2. the pointer must be aligned
3. the total size of the slice not to exceed `isize::MAX`

I focused on resolving the wide string conversion, but I also added a proposed fixed for arrays though I was unable to validate it.

Reference:
- https://github.com/rust-lang/rust/issues/123285
- https://github.com/rust-lang/rust/blob/a8773d53bea79d80e5e6ea0e602130be7faa6cbe/library/core/src/slice/raw.rs#L93
- https://github.com/rust-lang/rust/pull/120594/