### PR TITLE
update windows crate and add a util config function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,12 @@ time_rs = ["time"]
 serde = [ "dep:serde", "time?/serde", "time?/serde-human-readable" ]
 
 [dependencies]
-windows = { version = "0.57.0", features = [
+windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Security_Authorization",
     "Win32_System_Com",
+    "Win32_System_Ole",
+    "Win32_Security",
     "Win32_System_Diagnostics_Etw",
     "Win32_System_LibraryLoader",
     "Win32_System_Memory",
@@ -28,6 +30,7 @@ windows = { version = "0.57.0", features = [
     "Win32_System_SystemInformation",
     "Win32_System_SystemServices",
     "Win32_System_Time",
+    "Win32_System_Variant"
 ]}
 memoffset = "0.9"
 rand = "~0.8.0"

--- a/examples/dns.rs
+++ b/examples/dns.rs
@@ -59,7 +59,7 @@ fn parse_etw_event(schema: &Schema, record: &EventRecord) {
 fn main() {
     env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
 
-    let dns_provider = Provider::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
+    let dns_provider = Provider::by_guid(0x1c95126e_7eea_49a9_a3fe_a378b03ddb4d) // Microsoft-Windows-DNS-Client
         .add_callback(dns_etw_callback)
         .trace_flags(TraceFlags::EVENT_ENABLE_PROPERTY_PROCESS_START_KEY)
         .build();

--- a/examples/kernel_trace.rs
+++ b/examples/kernel_trace.rs
@@ -35,6 +35,7 @@ fn main() {
     let kernel_trace = KernelTrace::new()
         .named(String::from("MyKernelProvider"))
         .enable(provider)
+        .stop_if_exist(true)
         .start_and_process()
         .unwrap();
 

--- a/examples/multiple_providers.rs
+++ b/examples/multiple_providers.rs
@@ -52,11 +52,11 @@ fn tcpip_callback(record: &EventRecord, schema_locator: &SchemaLocator) {
 fn main() {
     env_logger::init(); // this is optional. This makes the (rare) error logs of ferrisetw to be printed to stderr
 
-    let tcpip_provider = Provider::by_guid("7dd42a49-5329-4832-8dfd-43d979153a88") // Microsoft-Windows-Kernel-Network
+    let tcpip_provider = Provider::by_guid(0x7dd42a49_5329_4832_8dfd_43d979153a88) // Microsoft-Windows-Kernel-Network
         .add_callback(tcpip_callback)
         .build();
 
-    let process_provider = Provider::by_guid("70eb4f03-c1de-4f73-a051-33d13d5413bd") // Microsoft-Windows-Kernel-Registry
+    let process_provider = Provider::by_guid(0x70eb4f03_c1de_4f73_a051_33d13d5413bd) // Microsoft-Windows-Kernel-Registry
         .add_callback(registry_callback)
         .build();
 

--- a/examples/user_trace.rs
+++ b/examples/user_trace.rs
@@ -30,7 +30,7 @@ fn main() {
             Err(err) => println!("Error {:?}", err),
         };
 
-    let process_provider = Provider::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
+    let process_provider = Provider::by_guid(0x22fb2cd6_0e7b_422b_a0c7_2fad1fd0e716) // Microsoft-Windows-Kernel-Process
         .add_callback(process_callback)
         .build();
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+hex_literal_case = "Lower"

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -13,13 +13,15 @@ use once_cell::sync::Lazy;
 use widestring::U16CStr;
 use windows::core::GUID;
 use windows::core::PCWSTR;
-use windows::Win32::Foundation::ERROR_ALREADY_EXISTS;
 use windows::Win32::Foundation::ERROR_CTX_CLOSE_PENDING;
 use windows::Win32::Foundation::ERROR_SUCCESS;
 use windows::Win32::Foundation::FILETIME;
+use windows::Win32::Foundation::{ERROR_ALREADY_EXISTS, ERROR_WMI_INSTANCE_NOT_FOUND};
 use windows::Win32::System::Diagnostics::Etw;
-use windows::Win32::System::Diagnostics::Etw::EVENT_CONTROL_CODE_ENABLE_PROVIDER;
-use windows::Win32::System::Diagnostics::Etw::TRACE_QUERY_INFO_CLASS;
+use windows::Win32::System::Diagnostics::Etw::{
+    EVENT_CONTROL_CODE_ENABLE_PROVIDER, EVENT_TRACE_CONTROL_QUERY,
+};
+use windows::Win32::System::Diagnostics::Etw::{EVENT_TRACE_CONTROL_STOP, TRACE_QUERY_INFO_CLASS};
 
 use super::etw_types::*;
 use crate::native::etw_types::event_record::EventRecord;
@@ -331,8 +333,8 @@ pub(crate) fn control_trace_by_name(
     properties: &mut EventTraceProperties,
     trace_name: &U16CStr,
     control_code: Etw::EVENT_TRACE_CONTROL,
-) -> EvntraceNativeResult<()> {
-    let result = unsafe {
+) -> windows::core::Result<()> {
+    unsafe {
         // Safety:
         //  * depending on the control code, the `Properties` can be mutated. This is fine because properties is declared as `&mut` in this function, which means no other Rust function has a reference to it, and the mutation can only happen in the call to `ControlTraceW`, which returns immediately.
         Etw::ControlTraceW(
@@ -342,11 +344,7 @@ pub(crate) fn control_trace_by_name(
             control_code,
         )
     }
-    .ok();
-
-    result.map_err(|err| {
-        EvntraceNativeError::IoError(std::io::Error::from_raw_os_error(err.code().0))
-    })
+    .ok()
 }
 
 /// Close the trace

--- a/src/native/pla.rs
+++ b/src/native/pla.rs
@@ -5,8 +5,10 @@
 //!
 //! This module shouldn't be accessed directly. Modules from the the crate level provide a safe API to interact
 //! with the crate
+use windows::core::BSTR;
+use windows::Win32::System::Variant::VARIANT;
 use windows::{
-    core::{GUID, VARIANT},
+    core::GUID,
     Win32::System::{
         Com::{CoCreateInstance, CoInitializeEx, CLSCTX_ALL, COINIT_MULTITHREADED},
         Performance::{ITraceDataProviderCollection, TraceDataProviderCollection},
@@ -38,7 +40,7 @@ pub(crate) unsafe fn get_provider_guid(name: &str) -> ProvidersComResult<GUID> {
     let all_providers: ITraceDataProviderCollection =
         unsafe { CoCreateInstance(&TraceDataProviderCollection, None, CLSCTX_ALL) }?;
 
-    all_providers.GetTraceDataProviders(None)?;
+    all_providers.GetTraceDataProviders(&BSTR::default())?;
 
     let count = all_providers.Count()? as u32;
 
@@ -49,7 +51,7 @@ pub(crate) unsafe fn get_provider_guid(name: &str) -> ProvidersComResult<GUID> {
         let provider = all_providers.get_Item(&VARIANT::from(index))?;
         let raw_name = provider.DisplayName()?;
 
-        let prov_name = String::from_utf16_lossy(raw_name.as_wide());
+        let prov_name = String::from_utf16_lossy(&raw_name);
 
         index += 1;
         // check if matches, if it does get guid and break
@@ -75,7 +77,10 @@ mod test {
             let guid =
                 get_provider_guid("Microsoft-Windows-Kernel-Process").expect("Error Getting GUID");
 
-            assert_eq!(GUID::from("22FB2CD6-0E7B-422B-A0C7-2FAD1FD0E716"), guid);
+            assert_eq!(
+                GUID::from_u128(0x22fb2cd6_0e7b_422b_a0c7_2fad1fd0e716),
+                guid
+            );
         }
     }
 

--- a/src/native/sddl.rs
+++ b/src/native/sddl.rs
@@ -1,8 +1,9 @@
 use core::ffi::c_void;
 use std::str::Utf8Error;
 use windows::core::PSTR;
-use windows::Win32::Foundation::{LocalFree, HLOCAL, PSID};
+use windows::Win32::Foundation::{LocalFree, HLOCAL};
 use windows::Win32::Security::Authorization::ConvertSidToStringSidA;
+use windows::Win32::Security::PSID;
 
 /// SDDL native error
 #[derive(Debug)]
@@ -40,7 +41,7 @@ pub fn convert_sid_to_string(sid: *const c_void) -> SddlResult<String> {
 
         let sid_string = std::ffi::CStr::from_ptr(tmp.0.cast()).to_str()?.to_owned();
 
-        if LocalFree(HLOCAL(tmp.0.cast())) != HLOCAL(std::ptr::null_mut()) {
+        if LocalFree(Some(HLOCAL(tmp.0.cast()))) != HLOCAL(std::ptr::null_mut()) {
             return Err(SddlNativeError::IoError(std::io::Error::last_os_error()));
         }
 

--- a/src/provider/event_filter.rs
+++ b/src/provider/event_filter.rs
@@ -1,7 +1,6 @@
 use std::alloc::Layout;
 use std::error::Error;
 
-use windows::Win32::Foundation::BOOLEAN;
 use windows::Win32::System::Diagnostics::Etw::{
     EVENT_FILTER_DESCRIPTOR, EVENT_FILTER_EVENT_ID, EVENT_FILTER_TYPE_EVENT_ID,
     EVENT_FILTER_TYPE_PID,
@@ -93,7 +92,7 @@ impl EventFilterDescriptor {
         // Fill the data with an array of `EVENT_FILTER_EVENT_ID`s
         let p = s.data.cast::<EVENT_FILTER_EVENT_ID>();
         unsafe {
-            (*p).FilterIn = BOOLEAN(1);
+            (*p).FilterIn = true;
             (*p).Reserved = 0;
             (*p).Count = eids.len() as u16; // we've checked the array was less than 1024 items
         }

--- a/src/provider/kernel_providers.rs
+++ b/src/provider/kernel_providers.rs
@@ -68,10 +68,10 @@ mod kernel_guids {
         [0x9d, 0xda, 0x00, 0xc0, 0x4f, 0xd7, 0xba, 0x7c],
     );
     pub const REGISTRY_GUID: GUID = GUID::from_values(
-        0xAE53722E,
-        0xC863,
+        0xae53722e,
+        0xc863,
         0x11d2,
-        [0x86, 0x59, 0x00, 0xC0, 0x4F, 0xA3, 0x21, 0xA1],
+        [0x86, 0x59, 0x00, 0xc0, 0x4f, 0xa3, 0x21, 0xa1],
     );
     pub const SPLIT_IO_GUID: GUID = GUID::from_values(
         0xd837ca92,
@@ -336,12 +336,14 @@ mod test {
 
     #[test]
     fn test_kernel_provider_struct() {
-        let kernel_provider =
-            KernelProvider::new("D396B546-287D-4712-A7F5-8BE226A8C643".into(), 0x10000);
+        let kernel_provider = KernelProvider::new(
+            GUID::from_u128(0xd396b546_287d_4712_a7f5_8be226a8c643),
+            0x10000,
+        );
 
         assert_eq!(0x10000, kernel_provider.flags);
         assert_eq!(
-            GUID::from("D396B546-287D-4712-A7F5-8BE226A8C643"),
+            GUID::from_u128(0xd396b546_287d_4712_a7f5_8be226a8c643),
             kernel_provider.guid
         );
     }
@@ -358,95 +360,95 @@ mod test {
     fn test_kernel_provider_guids_correct() {
         assert_eq!(
             ALPC_GUID,
-            GUID::from("45d8cccd-539f-4b72-a8b7-5c683142609a")
+            GUID::from_u128(0x45d8cccd_539f_4b72_a8b7_5c683142609a)
         );
         assert_eq!(
             POWER_GUID,
-            GUID::from("e43445e0-0903-48c3-b878-ff0fccebdd04")
+            GUID::from_u128(0xe43445e0_0903_48c3_b878_ff0fccebdd04)
         );
         assert_eq!(
             DEBUG_GUID,
-            GUID::from("13976d09-a327-438c-950b-7f03192815c7")
+            GUID::from_u128(0x13976d09_a327_438c_950b_7f03192815c7)
         );
         assert_eq!(
             TCP_IP_GUID,
-            GUID::from("9a280ac0-c8e0-11d1-84e2-00c04fb998a2")
+            GUID::from_u128(0x9a280ac0_c8e0_11d1_84e2_00c04fb998a2)
         );
         assert_eq!(
             UDP_IP_GUID,
-            GUID::from("bf3a50c5-a9c9-4988-a005-2df0b7c80f80")
+            GUID::from_u128(0xbf3a50c5_a9c9_4988_a005_2df0b7c80f80)
         );
         assert_eq!(
             THREAD_GUID,
-            GUID::from("3d6fa8d1-fe05-11d0-9dda-00c04fd7ba7c")
+            GUID::from_u128(0x3d6fa8d1_fe05_11d0_9dda_00c04fd7ba7c)
         );
         assert_eq!(
             DISK_IO_GUID,
-            GUID::from("3d6fa8d4-fe05-11d0-9dda-00c04fd7ba7c")
+            GUID::from_u128(0x3d6fa8d4_fe05_11d0_9dda_00c04fd7ba7c)
         );
         assert_eq!(
             FILE_IO_GUID,
-            GUID::from("90cbdc39-4a3e-11d1-84f4-0000f80464e3")
+            GUID::from_u128(0x90cbdc39_4a3e_11d1_84f4_0000f80464e3)
         );
         assert_eq!(
             PROCESS_GUID,
-            GUID::from("3d6fa8d0-fe05-11d0-9dda-00c04fd7ba7c")
+            GUID::from_u128(0x3d6fa8d0_fe05_11d0_9dda_00c04fd7ba7c)
         );
         assert_eq!(
             REGISTRY_GUID,
-            GUID::from("AE53722E-C863-11d2-8659-00C04FA321A1")
+            GUID::from_u128(0xae53722e_c863_11d2_8659_00c04fa321a1)
         );
         assert_eq!(
             SPLIT_IO_GUID,
-            GUID::from("d837ca92-12b9-44a5-ad6a-3a65b3578aa8")
+            GUID::from_u128(0xd837ca92_12b9_44a5_ad6a_3a65b3578aa8)
         );
         assert_eq!(
             OB_TRACE_GUID,
-            GUID::from("89497f50-effe-4440-8cf2-ce6b1cdcaca7")
+            GUID::from_u128(0x89497f50_effe_4440_8cf2_ce6b1cdcaca7)
         );
         assert_eq!(
             UMS_EVENT_GUID,
-            GUID::from("9aec974b-5b8e-4118-9b92-3186d8002ce5")
+            GUID::from_u128(0x9aec974b_5b8e_4118_9b92_3186d8002ce5)
         );
         assert_eq!(
             PERF_INFO_GUID,
-            GUID::from("ce1dbfb4-137e-4da6-87b0-3f59aa102cbc")
+            GUID::from_u128(0xce1dbfb4_137e_4da6_87b0_3f59aa102cbc)
         );
         assert_eq!(
             PAGE_FAULT_GUID,
-            GUID::from("3d6fa8d3-fe05-11d0-9dda-00c04fd7ba7c")
+            GUID::from_u128(0x3d6fa8d3_fe05_11d0_9dda_00c04fd7ba7c)
         );
         assert_eq!(
             IMAGE_LOAD_GUID,
-            GUID::from("2cb15d1d-5fc1-11d2-abe1-00a0c911f518")
+            GUID::from_u128(0x2cb15d1d_5fc1_11d2_abe1_00a0c911f518)
         );
         assert_eq!(
             POOL_TRACE_GUID,
-            GUID::from("0268a8b6-74fd-4302-9dd0-6e8f1795c0cf")
+            GUID::from_u128(0x0268a8b6_74fd_4302_9dd0_6e8f1795c0cf)
         );
         assert_eq!(
             LOST_EVENT_GUID,
-            GUID::from("6a399ae0-4bc6-4de9-870b-3657f8947e7e")
+            GUID::from_u128(0x6a399ae0_4bc6_4de9_870b_3657f8947e7e)
         );
         assert_eq!(
             STACK_WALK_GUID,
-            GUID::from("def2fe46-7bd6-4b80-bd94-f57fe20d0ce3")
+            GUID::from_u128(0xdef2fe46_7bd6_4b80_bd94_f57fe20d0ce3)
         );
         assert_eq!(
             EVENT_TRACE_GUID,
-            GUID::from("68fdd900-4a3e-11d1-84f4-0000f80464e3")
+            GUID::from_u128(0x68fdd900_4a3e_11d1_84f4_0000f80464e3)
         );
         assert_eq!(
             MMCSS_TRACE_GUID,
-            GUID::from("f8f10121-b617-4a56-868b-9df1b27fe32c")
+            GUID::from_u128(0xf8f10121_b617_4a56_868b_9df1b27fe32c)
         );
         assert_eq!(
             SYSTEM_TRACE_GUID,
-            GUID::from("9e814aad-3204-11d2-9a82-006008a86939")
+            GUID::from_u128(0x9e814aad_3204_11d2_9a82_006008a86939)
         );
         assert_eq!(
             EVENT_TRACE_CONFIG_GUID,
-            GUID::from("01853a65-418f-4f36-aefc-dc0f1d2fd235")
+            GUID::from_u128(0x01853a65_418f_4f36_aefc_dc0f1d2fd235)
         );
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use widestring::U16CString;
 use windows::core::GUID;
+use windows::Win32::Foundation::ERROR_WMI_INSTANCE_NOT_FOUND;
 use windows::Win32::System::Diagnostics::Etw;
 
 use self::private::{PrivateRealTimeTraceTrait, PrivateTraceTrait};
@@ -18,7 +19,7 @@ use crate::native::evntrace::{
     close_trace, control_trace, control_trace_by_name, enable_provider, open_trace, process_trace,
     start_trace, ControlHandle, TraceHandle,
 };
-use crate::native::version_helper;
+use crate::native::{version_helper, EvntraceNativeError};
 use crate::provider::Provider;
 use crate::utils;
 use crate::EventRecord;
@@ -33,7 +34,7 @@ use callback_data::CallbackDataFromFile;
 use callback_data::RealTimeCallbackData;
 
 const KERNEL_LOGGER_NAME: &str = "NT Kernel Logger";
-const SYSTEM_TRACE_CONTROL_GUID: &str = "9e814aad-3204-11d2-9a82-006008a86939";
+const SYSTEM_TRACE_CONTROL_GUID: GUID = GUID::from_u128(0x9e814aad_3204_11d2_9a82_006008a86939);
 const EVENT_TRACE_SYSTEM_LOGGER_MODE: u32 = 0x02000000;
 
 /// Trace module errors
@@ -166,7 +167,7 @@ impl RealTimeTraceTrait for KernelTrace {
         if version_helper::is_win8_or_greater() {
             GUID::new().unwrap_or(GUID::zeroed())
         } else {
-            GUID::from(SYSTEM_TRACE_CONTROL_GUID)
+            SYSTEM_TRACE_CONTROL_GUID
         }
     }
 
@@ -246,6 +247,7 @@ pub struct TraceBuilder<T: RealTimeTraceTrait> {
     etl_dump_file: Option<DumpFileParams>,
     properties: TraceProperties,
     rt_callback_data: RealTimeCallbackData,
+    stop_if_exist: bool,
     trace_kind: PhantomData<T>,
 }
 
@@ -263,6 +265,7 @@ impl UserTrace {
             etl_dump_file: None,
             rt_callback_data: RealTimeCallbackData::new(),
             properties: TraceProperties::default(),
+            stop_if_exist: true,
             trace_kind: PhantomData,
         }
     }
@@ -284,6 +287,7 @@ impl KernelTrace {
             etl_dump_file: None,
             rt_callback_data: RealTimeCallbackData::new(),
             properties: TraceProperties::default(),
+            stop_if_exist: true,
             trace_kind: PhantomData,
         };
         // Not all names are valid. Let's use the setter to check them for us
@@ -468,6 +472,11 @@ impl<T: RealTimeTraceTrait + PrivateRealTimeTraceTrait> TraceBuilder<T> {
         self
     }
 
+    pub fn stop_if_exist(mut self, b: bool) -> Self {
+        self.stop_if_exist = b;
+        self
+    }
+
     /// Build the `UserTrace` and start the trace session
     ///
     /// Internally, this calls the `StartTraceW`, `EnableTraceEx2` and `OpenTraceW`.
@@ -482,6 +491,9 @@ impl<T: RealTimeTraceTrait + PrivateRealTimeTraceTrait> TraceBuilder<T> {
     ///   This convenience function spawns a thread for you, call [`TraceBuilder::start`] on the trace, and returns immediately.<br/>
     ///   This option returns a `T`, so you can explicitly stop the trace, but there is no way to get the status code of the ProcessTrace API.
     pub fn start(self) -> TraceResult<(T, TraceHandle)> {
+        if self.stop_if_exist {
+            stop_trace_by_name(&self.name)?;
+        }
         // Prepare a wide version of the trace name
         let trace_wide_name = U16CString::from_str_truncate(self.name);
         let mut trace_wide_vec = trace_wide_name.into_vec();
@@ -643,7 +655,16 @@ pub fn stop_trace_by_name(trace_name: &str) -> TraceResult<()> {
         flags,
     );
 
-    control_trace_by_name(&mut properties, &wide_name, Etw::EVENT_TRACE_CONTROL_STOP)?;
+    let result = control_trace_by_name(&mut properties, &wide_name, Etw::EVENT_TRACE_CONTROL_STOP);
+    if let Err(e) = result {
+        if e.code() == ERROR_WMI_INSTANCE_NOT_FOUND.to_hresult() {
+            // This is not an error, it just means the trace was not running
+            return Ok(());
+        }
+        return Err(TraceError::EtwNativeError(EvntraceNativeError::IoError(
+            std::io::Error::from_raw_os_error(e.code().0),
+        )));
+    }
 
     Ok(())
 }
@@ -654,8 +675,8 @@ mod test {
 
     #[test]
     fn test_enable_multiple_providers() {
-        let prov = Provider::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716").build();
-        let prov1 = Provider::by_guid("A0C1853B-5C40-4B15-8766-3CF1C58F985A").build();
+        let prov = Provider::by_guid(0x22fb2cd6_0e7b_422b_a0c7_2fad1fd0e716).build();
+        let prov1 = Provider::by_guid(0xa0c1853b_5c40_4b15_8766_3cf1c58f985a).build();
 
         let trace_builder = UserTrace::new().enable(prov).enable(prov1);
 

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -30,7 +30,7 @@ fn simple_user_dns_trace() {
     let passed = Status::new(TestKind::ExpectSuccess);
     let notifier = passed.notifier();
 
-    let dns_provider = Provider::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
+    let dns_provider = Provider::by_guid(0x1c95126e_7eea_49a9_a3fe_a378b03ddb4d) // Microsoft-Windows-DNS-Client
         .add_callback(
             move |record: &EventRecord, schema_locator: &SchemaLocator| {
                 let schema = schema_locator.event_schema(record).unwrap();
@@ -70,7 +70,7 @@ fn test_event_id_filter() {
 
     let filter = EventFilter::ByEventIds(vec![EVENT_ID_DNS_QUERY_COMPLETED]);
 
-    let dns_provider = Provider::by_guid("1c95126e-7eea-49a9-a3fe-a378b03ddb4d") // Microsoft-Windows-DNS-Client
+    let dns_provider = Provider::by_guid(0x1c95126e_7eea_49a9_a3fe_a378b03ddb4d) // Microsoft-Windows-DNS-Client
         .add_filter(filter)
         .add_callback(
             move |record: &EventRecord, _schema_locator: &SchemaLocator| {

--- a/tests/file_trace.rs
+++ b/tests/file_trace.rs
@@ -26,7 +26,7 @@ fn etl_file() {
 fn empty_callback(_record: &EventRecord, _schema_locator: &SchemaLocator) {}
 
 fn save_a_trace(dump_file: DumpFileParams) -> usize {
-    let process_provider = Provider::by_guid("22fb2cd6-0e7b-422b-a0c7-2fad1fd0e716") // Microsoft-Windows-Kernel-Process
+    let process_provider = Provider::by_guid(0x22fb2cd6_0e7b_422b_a0c7_2fad1fd0e716) // Microsoft-Windows-Kernel-Process
         .add_callback(empty_callback)
         .build();
 

--- a/tests/kernel_trace.rs
+++ b/tests/kernel_trace.rs
@@ -67,8 +67,7 @@ fn load_library(libname: &str) {
     let widename = HSTRING::from(libname);
 
     // Safety: LoadLibraryExW expects a valid string in lpLibFileName.
-    let res =
-        unsafe { LoadLibraryExW(&widename, HANDLE::default(), LOAD_LIBRARY_FLAGS::default()) };
+    let res = unsafe { LoadLibraryExW(&widename, None, LOAD_LIBRARY_FLAGS::default()) };
 
     res.unwrap();
 }

--- a/tests/tlg.rs
+++ b/tests/tlg.rs
@@ -5,7 +5,7 @@ use ferrisetw::provider::Provider;
 use ferrisetw::schema_locator::SchemaLocator;
 use ferrisetw::trace::TraceTrait;
 use ferrisetw::trace::UserTrace;
-use ferrisetw::EventRecord;
+use ferrisetw::{EventRecord, GUID};
 
 mod utils;
 use utils::{Status, TestKind};
@@ -20,6 +20,7 @@ tlg::define_provider!(FERRIS_PROVIDER, "ferrisETW.TraceLoggingTest");
 #[ignore]
 #[test]
 fn tlg_tests() {
+    use std::convert::TryInto;
     unsafe {
         FERRIS_PROVIDER.register();
     }
@@ -27,7 +28,7 @@ fn tlg_tests() {
     let binding = tlg::Guid::from_name(PROVIDER_NAME).to_utf8_bytes();
     let guid = std::str::from_utf8(&binding).unwrap();
 
-    tlg_multiple_events(guid);
+    tlg_multiple_events(guid.try_into().unwrap());
 
     FERRIS_PROVIDER.unregister();
 }
@@ -54,7 +55,7 @@ fn generate_tlg_events() {
     }
 }
 
-fn tlg_multiple_events(provider_guid: &str) {
+fn tlg_multiple_events(provider_guid: GUID) {
     let passed = Status::new(TestKind::ExpectSuccess);
     let notifier = passed.notifier();
 

--- a/tests/trace_lifetime.rs
+++ b/tests/trace_lifetime.rs
@@ -75,7 +75,7 @@ fn test_wordpad_trace(
     );
 
     // Create a provider
-    let mut provider_builder = Provider::by_guid("54FFD262-99FE-4576-96E7-1ADB500370DC"); // Microsoft-Windows-Wordpad
+    let mut provider_builder = Provider::by_guid(0x54ffd262_99fe_4576_96e7_1adb500370dc); // Microsoft-Windows-Wordpad
     for _i in 0..provider_count {
         provider_builder =
             provider_builder.add_callback(|_record: &EventRecord, _locator: &SchemaLocator| {})


### PR DESCRIPTION
- updates windows crate
- GUID no longer support `From<&str>`, replace by `u128`
- added a `stop_if_exist` to `TraceBuilder`