### PR TITLE
feat: use TraceSetInformation to enable flags for kernel providers

### DIFF
--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -464,3 +464,35 @@ impl From<Etw::DECODING_SOURCE> for DecodingSource {
 // Safe cast (EVENT_HEADER_FLAG_32_BIT_HEADER = 32)
 #[doc(hidden)]
 pub const EVENT_HEADER_FLAG_32_BIT_HEADER: u16 = Etw::EVENT_HEADER_FLAG_32_BIT_HEADER as u16;
+
+pub const PERF_MASK_INDEX: u32 = 0xe0000000;
+pub const PERF_MASK_INDEX_SHIFT: u32 = 29;
+pub const PERF_MASK_GROUP: u32 = !PERF_MASK_INDEX;
+pub const PERF_NUM_MASKS: u32 = 8;
+
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct PERFINFO_GROUPMASK {
+    pub masks: [u32; PERF_NUM_MASKS as usize],
+}
+
+impl PERFINFO_GROUPMASK {
+    pub fn new() -> Self {
+        Self {
+            masks: [0u32; PERF_NUM_MASKS as usize],
+        }
+    }
+    pub fn get_mask_index(gm: u32) -> u32 {
+        (gm & PERF_MASK_INDEX) >> PERF_MASK_INDEX_SHIFT
+    }
+
+    pub fn get_mask_group(gm: u32) -> u32 {
+        gm & PERF_MASK_GROUP
+    }
+
+    pub fn or_assign_with_groupmask(&mut self, gm: u32) {
+        self.masks[PERFINFO_GROUPMASK::get_mask_index(gm) as usize] |=
+            PERFINFO_GROUPMASK::get_mask_group(gm);
+    }
+}

--- a/src/native/evntrace.rs
+++ b/src/native/evntrace.rs
@@ -3,8 +3,11 @@
 //! This module makes sure the calls are safe memory-wise, but does not attempt to ensure they are called in the right order.<br/>
 //! Thus, you should prefer using `UserTrace`s, `KernelTrace`s and `TraceBuilder`s, that will ensure these API are correctly used.
 use std::collections::HashSet;
+use std::ffi;
 use std::ffi::c_void;
+use std::mem;
 use std::panic::AssertUnwindSafe;
+use std::ptr;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -18,6 +21,8 @@ use windows::Win32::Foundation::ERROR_SUCCESS;
 use windows::Win32::Foundation::FILETIME;
 use windows::Win32::Foundation::{ERROR_ALREADY_EXISTS, ERROR_WMI_INSTANCE_NOT_FOUND};
 use windows::Win32::System::Diagnostics::Etw;
+use windows::Win32::System::Diagnostics::Etw::TraceSetInformation;
+use windows::Win32::System::Diagnostics::Etw::TraceSystemTraceEnableFlagsInfo;
 use windows::Win32::System::Diagnostics::Etw::{
     EVENT_CONTROL_CODE_ENABLE_PROVIDER, EVENT_TRACE_CONTROL_QUERY,
 };
@@ -231,7 +236,7 @@ pub(crate) fn open_trace(
 }
 
 /// Attach a provider to a trace
-pub(crate) fn enable_provider(
+pub(crate) fn enable_user_provider(
     control_handle: ControlHandle,
     provider: &Provider,
 ) -> EvntraceNativeResult<()> {
@@ -260,6 +265,30 @@ pub(crate) fn enable_provider(
                     provider.all(),
                     0,
                     Some(parameters.as_ptr()),
+                )
+            }
+            .ok();
+
+            res.map_err(|err| {
+                EvntraceNativeError::IoError(std::io::Error::from_raw_os_error(err.code().0))
+            })
+        }
+    }
+}
+
+pub(crate) fn enable_kernel_providers(
+    control_handle: ControlHandle,
+    gm: PERFINFO_GROUPMASK,
+) -> EvntraceNativeResult<()> {
+    match filter_invalid_control_handle(control_handle) {
+        None => Err(EvntraceNativeError::InvalidHandle),
+        Some(handle) => {
+            let res = unsafe {
+                TraceSetInformation(
+                    handle,
+                    TraceSystemTraceEnableFlagsInfo,
+                    ptr::addr_of!(gm) as *const ffi::c_void,
+                    mem::size_of_val(&gm) as u32,
                 )
             }
             .ok();

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -44,6 +44,8 @@ pub struct Provider {
     trace_flags: TraceFlags,
     /// Provider kernel flags, only apply to KernelProvider
     kernel_flags: u32,
+    /// Provider extended kernel flags, only apply to KernelProvider
+    extended_kernel_flags: Vec<u32>,
     /// Provider filters
     filters: Vec<EventFilter>,
     /// Callbacks that will receive events from this Provider
@@ -60,6 +62,7 @@ pub struct ProviderBuilder {
     level: u8,
     trace_flags: TraceFlags,
     kernel_flags: u32,
+    extended_kernel_flags: Vec<u32>,
     filters: Vec<EventFilter>,
     callbacks: Arc<RwLock<Vec<crate::EtwCallback>>>,
 }
@@ -73,6 +76,7 @@ impl std::fmt::Debug for ProviderBuilder {
             .field("level", &self.level)
             .field("trace_flags", &self.trace_flags)
             .field("kernel_flags", &self.kernel_flags)
+            .field("extended_kernel_flags", &self.extended_kernel_flags)
             .field("filters", &self.filters)
             .field("n_callbacks", &self.callbacks.read().unwrap().len())
             .finish()
@@ -93,6 +97,7 @@ impl Provider {
             level: 5,
             trace_flags: TraceFlags::empty(),
             kernel_flags: 0,
+            extended_kernel_flags: Vec::new(),
             filters: Vec::new(),
             callbacks: Arc::new(RwLock::new(Vec::new())),
         }
@@ -104,6 +109,7 @@ impl Provider {
     pub fn kernel(kernel_provider: &kernel_providers::KernelProvider) -> ProviderBuilder {
         let mut builder = Self::by_guid(kernel_provider.guid);
         builder.kernel_flags = kernel_provider.flags;
+        builder.extended_kernel_flags = kernel_provider.extended_flags.clone();
         builder
     }
 
@@ -145,6 +151,9 @@ impl Provider {
     }
     pub fn kernel_flags(&self) -> u32 {
         self.kernel_flags
+    }
+    pub fn extended_kernel_flags(&self) -> &[u32] {
+        &self.extended_kernel_flags
     }
     pub fn filters(&self) -> &[EventFilter] {
         &self.filters
@@ -301,6 +310,7 @@ impl ProviderBuilder {
             level: self.level,
             trace_flags: self.trace_flags,
             kernel_flags: self.kernel_flags,
+            extended_kernel_flags: self.extended_kernel_flags,
             filters: self.filters,
             callbacks: self.callbacks,
         }

--- a/src/provider/kernel_providers.rs
+++ b/src/provider/kernel_providers.rs
@@ -193,12 +193,18 @@ pub struct KernelProvider {
     pub guid: GUID,
     /// Kernel Provider Flags
     pub flags: u32,
+    /// Kernel Provider Extended Flags
+    pub extended_flags: Vec<u32>,
 }
 
 impl KernelProvider {
     /// Use the `new` function to create a Kernel Provider which can be then tied into a Provider
     pub const fn new(guid: GUID, flags: u32) -> KernelProvider {
-        KernelProvider { guid, flags }
+        KernelProvider {
+            guid,
+            flags,
+            extended_flags: Vec::new(),
+        }
     }
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -14,10 +14,10 @@ use windows::Win32::System::Diagnostics::Etw;
 
 use self::private::{PrivateRealTimeTraceTrait, PrivateTraceTrait};
 
-use crate::native::etw_types::{EventTraceProperties, SubscriptionSource};
+use crate::native::etw_types::{EventTraceProperties, SubscriptionSource, PERFINFO_GROUPMASK};
 use crate::native::evntrace::{
-    close_trace, control_trace, control_trace_by_name, enable_provider, open_trace, process_trace,
-    start_trace, ControlHandle, TraceHandle,
+    close_trace, control_trace, control_trace_by_name, enable_kernel_providers,
+    enable_user_provider, open_trace, process_trace, start_trace, ControlHandle, TraceHandle,
 };
 use crate::native::{version_helper, EvntraceNativeError};
 use crate::provider::Provider;
@@ -157,7 +157,6 @@ impl RealTimeTraceTrait for UserTrace {
     }
 }
 
-// TODO: Implement enable_provider function for providers that require call to TraceSetInformation with extended PERFINFO_GROUPMASK
 impl TraceTrait for KernelTrace {
     fn trace_handle(&self) -> TraceHandle {
         self.trace_handle
@@ -543,11 +542,22 @@ impl<T: RealTimeTraceTrait + PrivateRealTimeTraceTrait> TraceBuilder<T> {
             flags,
         )?;
 
-        // TODO: For kernel traces, implement enable_provider function for providers that require call to TraceSetInformation with extended PERFINFO_GROUPMASK
+        match T::TRACE_KIND {
+            private::TraceKind::User => {
+                for prov in self.rt_callback_data.providers() {
+                    enable_user_provider(control_handle, prov)?;
+                }
+            }
+            private::TraceKind::Kernel => {
+                let mut gm = PERFINFO_GROUPMASK::new();
+                for provider in self.rt_callback_data.providers() {
+                    gm.or_assign_with_groupmask(provider.kernel_flags());
+                    for flag in provider.extended_kernel_flags() {
+                        gm.or_assign_with_groupmask(*flag);
+                    }
+                }
 
-        if T::TRACE_KIND == private::TraceKind::User {
-            for prov in self.rt_callback_data.providers() {
-                enable_provider(control_handle, prov)?;
+                enable_kernel_providers(control_handle, gm)?;
             }
         }
 


### PR DESCRIPTION
We copied some of this code from [system_monitor](https://github.com/wuanzhuan/system_monitor/blob/main/src/event_trace/event_kernel.rs#L2220) (which is licensed Apache, so should be alright), and it seems like they copied it from KrabsETW (https://github.com/microsoft/krabsetw/blob/master/krabs/krabs/perfinfo_groupmask.hpp)

Piping the extended flags is annoying and requires an additional vector of flags because they cannot be simply ORd with each other due to their overlapping nature. Let me know if you want me to implement this in a different way.