### PR TITLE
Extend support for MOF traces & parse reversed counted strings

### DIFF
--- a/src/native/tdh_types.rs
+++ b/src/native/tdh_types.rs
@@ -197,6 +197,8 @@ pub enum TdhInType {
     InTypeHexInt64,
     InTypeCountedString = 300,
     InTypeCountedAnsiString,
+    InTypeReversedCountedString,
+    InTypeReversedCountedAnsiString,
 }
 
 /// Represent a TDH_OUT_TYPE

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -521,6 +521,38 @@ impl private::TryParse<String> for Parser<'_, '_> {
                     )?;
                     Ok(string.to_string())
                 }
+                TdhInType::InTypeReversedCountedAnsiString => unimplemented!(),
+                TdhInType::InTypeReversedCountedString => {
+                    if prop_slice.buffer.len() < 2 {
+                        return Err(ParserError::PropertyError(
+                            "counted string does not have length".into(),
+                        ));
+                    }
+                    let str_length = u16::from_be_bytes(
+                        prop_slice.buffer[..std::mem::size_of::<u16>()]
+                            .try_into()
+                            .unwrap(),
+                    ) as usize;
+                    if prop_slice.buffer[std::mem::size_of::<u16>()..].len() < str_length {
+                        return Err(ParserError::PropertyError(
+                            "invalid counted string length".into(),
+                        ));
+                    }
+
+                    let mut aligned_buffer = Vec::with_capacity(prop_slice.buffer.len() / 2 - 2);
+                    for chunk in prop_slice.buffer.chunks_exact(2).skip(1) {
+                        let part = u16::from_ne_bytes([chunk[0], chunk[1]]);
+                        aligned_buffer.push(part);
+                    }
+                    let mut wide = aligned_buffer.as_slice();
+
+                    match wide.last() {
+                        // remove the null terminator from the slice
+                        Some(c) if c == &0 => wide = &wide[..wide.len() - 1],
+                        _ => (),
+                    }
+                    Ok(widestring::decode_utf16_lossy(wide.iter().copied()).collect::<String>())
+                }
                 _ => Err(ParserError::InvalidType),
             },
             _ => Err(ParserError::InvalidType),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,6 +5,7 @@ use crate::native::etw_types::DecodingSource;
 use crate::native::tdh::TraceEventInfo;
 use crate::native::tdh_types::{Property, PropertyError};
 use once_cell::sync::OnceCell;
+use windows::core::GUID;
 
 /// A schema suitable for parsing a given kind of event.
 ///
@@ -58,6 +59,22 @@ impl Schema {
     /// [TraceEventInfo]: crate::native::tdh::TraceEventInfo
     pub fn provider_name(&self) -> String {
         self.te_info.provider_name()
+    }
+
+    /// Use the `provider_guid` function to obtain the Provider GUID from the `TRACE_EVENT_INFO`
+    ///
+    /// # Example
+    /// ```
+    /// # use ferrisetw::EventRecord;
+    /// # use ferrisetw::schema_locator::SchemaLocator;
+    /// let my_callback = |record: &EventRecord, schema_locator: &SchemaLocator| {
+    ///     let schema = schema_locator.event_schema(record).unwrap();
+    ///     let provider_guid = schema.provider_guid();
+    /// };
+    /// ```
+    /// [TraceEventInfo]: crate::native::tdh::TraceEventInfo
+    pub fn provider_guid(&self) -> GUID {
+        self.te_info.provider_guid()
     }
 
     /// Use the `task_name` function to obtain the Task name from the `TRACE_EVENT_INFO`

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -277,7 +277,7 @@ impl UserTrace {
         TraceBuilder {
             name,
             etl_dump_file: None,
-            rt_callback_data: RealTimeCallbackData::new(),
+            rt_callback_data: RealTimeCallbackData::new(private::TraceKind::User),
             properties: TraceProperties::default(),
             stop_if_exist: true,
             trace_kind: PhantomData,
@@ -299,7 +299,7 @@ impl KernelTrace {
         let builder = TraceBuilder {
             name: String::new(),
             etl_dump_file: None,
-            rt_callback_data: RealTimeCallbackData::new(),
+            rt_callback_data: RealTimeCallbackData::new(private::TraceKind::Kernel),
             properties: TraceProperties::default(),
             stop_if_exist: true,
             trace_kind: PhantomData,

--- a/src/trace/callback_data.rs
+++ b/src/trace/callback_data.rs
@@ -4,8 +4,10 @@ use std::sync::RwLock;
 use windows::Win32::System::Diagnostics::Etw;
 
 use crate::native::etw_types::event_record::EventRecord;
+use crate::native::DecodingSource;
 use crate::provider::Provider;
 use crate::schema_locator::SchemaLocator;
+use crate::trace::private::TraceKind;
 use crate::trace::RealTimeTraceTrait;
 use crate::EtwCallback;
 
@@ -25,6 +27,8 @@ pub struct RealTimeCallbackData {
     schema_locator: SchemaLocator,
     /// List of Providers associated with the Trace. This also owns the callback closures and their state
     providers: Vec<Provider>,
+    /// Type of the trace
+    trace_kind: TraceKind,
 }
 
 pub struct CallbackDataFromFile {
@@ -51,19 +55,14 @@ impl CallbackData {
     }
 }
 
-impl std::default::Default for RealTimeCallbackData {
-    fn default() -> Self {
+impl RealTimeCallbackData {
+    pub fn new(kind: TraceKind) -> Self {
         Self {
             events_handled: AtomicUsize::new(0),
             schema_locator: SchemaLocator::new(),
             providers: Vec::new(),
+            trace_kind: kind,
         }
-    }
-}
-
-impl RealTimeCallbackData {
-    pub fn new() -> Self {
-        Default::default()
     }
 
     pub fn add_provider(&mut self, provider: Provider) {
@@ -86,9 +85,40 @@ impl RealTimeCallbackData {
     pub fn on_event(&self, record: &EventRecord) {
         self.events_handled.fetch_add(1, Ordering::Relaxed);
 
-        for prov in &self.providers {
-            if prov.guid() == record.provider_id() {
-                prov.on_event(record, &self.schema_locator);
+        // Get event type
+        match self.trace_kind {
+            TraceKind::Kernel => {
+                for prov in &self.providers {
+                    if prov.guid() == record.provider_id() {
+                        prov.on_event(record, &self.schema_locator);
+                    }
+                }
+            }
+            TraceKind::User => {
+                let schema = self.schema_locator.event_schema(record).unwrap();
+                let decoding_source = schema.decoding_source();
+                match decoding_source {
+                    DecodingSource::DecodingSourceXMLFile
+                    | DecodingSource::DecodingSourceTlg
+                    | DecodingSource::DecodingSourceMax => {
+                        // for manifest/TraceLogging providers, EventHeader.ProviderId is the Provider GUID
+                        for prov in &self.providers {
+                            if prov.guid() == record.provider_id() {
+                                prov.on_event(record, &self.schema_locator);
+                            }
+                        }
+                    }
+                    DecodingSource::DecodingSourceWbem | DecodingSource::DecodingSourceWPP => {
+                        // for MOF/WPP providers, EventHeader.Provider is the *Message* GUID
+                        // we need to ask TDH for event information in order to determine the
+                        // correct provider to pass this event to
+                        for prov in &self.providers {
+                            if prov.guid() == schema.provider_guid() {
+                                prov.on_event(record, &self.schema_locator);
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/trace/callback_data.rs
+++ b/src/trace/callback_data.rs
@@ -95,30 +95,41 @@ impl RealTimeCallbackData {
                 }
             }
             TraceKind::User => {
-                let schema = self.schema_locator.event_schema(record).unwrap();
-                let decoding_source = schema.decoding_source();
-                match decoding_source {
-                    DecodingSource::DecodingSourceXMLFile
-                    | DecodingSource::DecodingSourceTlg
-                    | DecodingSource::DecodingSourceMax => {
-                        // for manifest/TraceLogging providers, EventHeader.ProviderId is the Provider GUID
+                match self.schema_locator.event_schema(record) {
+                    Ok(schema) => {
+                        match schema.decoding_source() {
+                            DecodingSource::DecodingSourceXMLFile
+                            | DecodingSource::DecodingSourceTlg
+                            | DecodingSource::DecodingSourceMax => {
+                                // for manifest/TraceLogging providers, EventHeader.ProviderId is the Provider GUID
+                                for prov in &self.providers {
+                                    if prov.guid() == record.provider_id() {
+                                        prov.on_event(record, &self.schema_locator);
+                                    }
+                                }
+                            }
+                            DecodingSource::DecodingSourceWbem
+                            | DecodingSource::DecodingSourceWPP => {
+                                // for MOF/WPP providers, EventHeader.Provider is the *Message* GUID
+                                // we need to ask TDH for event information in order to determine the
+                                // correct provider to pass this event to
+                                for prov in &self.providers {
+                                    if prov.guid() == schema.provider_guid() {
+                                        prov.on_event(record, &self.schema_locator);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        // If we failed to get the schema and cannot get the decoding source, use the default dispatch method.
                         for prov in &self.providers {
                             if prov.guid() == record.provider_id() {
                                 prov.on_event(record, &self.schema_locator);
                             }
                         }
                     }
-                    DecodingSource::DecodingSourceWbem | DecodingSource::DecodingSourceWPP => {
-                        // for MOF/WPP providers, EventHeader.Provider is the *Message* GUID
-                        // we need to ask TDH for event information in order to determine the
-                        // correct provider to pass this event to
-                        for prov in &self.providers {
-                            if prov.guid() == schema.provider_guid() {
-                                prov.on_event(record, &self.schema_locator);
-                            }
-                        }
-                    }
-                }
+                };
             }
         }
     }


### PR DESCRIPTION
Closes #157 

This PR does the following:
- Add the support to `InTypeReversedCountedString` parsing
- Fix GUID check the event forwarding logic for MOF user traces

The second point fixes events for MOF user traces events not being sent to registered callback. This was caused by the GUID check in the on_event function of the RealTimeCallbackData struct. When using MOF user traces, the GUID is located in the schema, because EventHeader.Provider is the message GUID, not the actual provider GUID (cf the discrepancy in the equivalent code in Krabs: https://github.com/microsoft/krabsetw/blob/8c0ea124b96a9054de3d07e04cda8614da885fc9/krabs/krabs/ut.hpp#L227)