### PR TITLE
Parser performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ serde = { version = "1.0", optional = true }
 # thiserror = "~1.0"
 # anyhow = "~1.0"
 log = "0.4"
+rustc-hash = "2"
 
 [dev-dependencies]
 env_logger = "0.11" # used in examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrisetw"
-version = "1.2.0"
+version = "1.2.1"
 license = "MIT OR Apache-2.0"
 description = "Basically a KrabsETW rip-off written in Rust"
 keywords = ["etw", "krabsetw", "event", "tracing", "windows"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::native::time::{FileTime, SystemTime};
 use crate::property::PropertySlice;
 use crate::schema::Schema;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::convert::TryInto;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use windows::core::GUID;
@@ -87,7 +87,7 @@ type ParserResult<T> = Result<T, ParserError>;
 /// This is useful because computing their offset can be costly
 struct CachedSlices<'schema, 'record> {
     /// Keyed by borrowed property names from the schema; avoids a heap allocation per insertion.
-    slices: HashMap<&'schema str, PropertySlice<'schema, 'record>>,
+    slices: FxHashMap<&'schema str, PropertySlice<'schema, 'record>>,
     /// The user buffer index we've cached up to
     last_cached_offset: usize,
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,7 +86,8 @@ type ParserResult<T> = Result<T, ParserError>;
 ///
 /// This is useful because computing their offset can be costly
 struct CachedSlices<'schema, 'record> {
-    slices: HashMap<String, PropertySlice<'schema, 'record>>,
+    /// Keyed by borrowed property names from the schema; avoids a heap allocation per insertion.
+    slices: HashMap<&'schema str, PropertySlice<'schema, 'record>>,
     /// The user buffer index we've cached up to
     last_cached_offset: usize,
 }
@@ -295,9 +296,9 @@ impl<'schema, 'record> Parser<'schema, 'record> {
                 property,
                 buffer: property_buffer,
             };
-            cache
-                .slices
-                .insert(String::clone(&property.name), prop_slice);
+            // Borrow the name from the schema slice (lifetime `'schema`) to avoid a heap
+            // allocation per property per event.
+            cache.slices.insert(property.name.as_str(), prop_slice);
             cache.last_cached_offset += prop_size;
 
             if property.name == name {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,10 +11,10 @@ use crate::native::tdh_types::{
 use crate::native::time::{FileTime, SystemTime};
 use crate::property::PropertySlice;
 use crate::schema::Schema;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::sync::Mutex;
 use windows::core::GUID;
 
 /// Parser module errors
@@ -117,11 +117,14 @@ struct CachedSlices<'schema, 'record> {
 ///     }
 /// };
 /// ```
+// `Parser` is intentionally `!Sync` via `RefCell`. ETW's `ProcessTrace` delivers events
+// sequentially on a single thread, so a `Parser` is always created and consumed within a single
+// callback invocation and is never shared across threads.
 #[allow(dead_code)]
 pub struct Parser<'schema, 'record> {
     properties: &'schema [Property],
     record: &'record EventRecord,
-    cache: Mutex<CachedSlices<'schema, 'record>>,
+    cache: RefCell<CachedSlices<'schema, 'record>>,
 }
 
 impl<'schema, 'record> Parser<'schema, 'record> {
@@ -144,7 +147,7 @@ impl<'schema, 'record> Parser<'schema, 'record> {
         Parser {
             record: event_record,
             properties: schema.properties(),
-            cache: Mutex::new(CachedSlices::default()),
+            cache: RefCell::new(CachedSlices::default()),
         }
     }
 
@@ -172,9 +175,9 @@ impl<'schema, 'record> Parser<'schema, 'record> {
                 let prop_len = match length {
                     PropertyLength::Length(l) => l,
                     PropertyLength::Index(_) => {
-                        // TODO optimize to cache the lookup, the problem is here this is called under an
-                        // exclusive mutex, so attempting to extract and cache a related property will
-                        // deadlock.
+                        // TODO: optimize to cache the lookup; the problem is that this is called
+                        // whilst the `RefCell` borrow on `CachedSlices` is already active, so
+                        // re-entering `find_property` to cache the related property would panic.
                         return Ok(tdh::property_size(self.record, &property.name)? as usize);
                     }
                 };
@@ -240,9 +243,9 @@ impl<'schema, 'record> Parser<'schema, 'record> {
                 let prop_count = match count {
                     PropertyCount::Count(c) => c as usize,
                     PropertyCount::Index(_) => {
-                        // TODO optimize to cache the lookup, the problem is here this is called under an
-                        // exclusive mutex, so attempting to extract and cache a related property will
-                        // deadlock.
+                        // TODO: optimize to cache the lookup; the problem is that this is called
+                        // whilst the `RefCell` borrow on `CachedSlices` is already active, so
+                        // re-entering `find_property` to cache the related property would panic.
                         return Ok(tdh::property_size(self.record, &property.name)? as usize);
                     }
                 };
@@ -257,7 +260,7 @@ impl<'schema, 'record> Parser<'schema, 'record> {
     }
 
     fn find_property(&self, name: &str) -> ParserResult<PropertySlice<'schema, 'record>> {
-        let mut cache = self.cache.lock().unwrap();
+        let mut cache = self.cache.borrow_mut();
 
         // We may have extracted this property already
         if let Some(p) = cache.slices.get(name) {

--- a/src/schema_locator.rs
+++ b/src/schema_locator.rs
@@ -1,7 +1,8 @@
 //! A way to cache and retrieve Schemas
 
+use std::cell::UnsafeCell;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use windows::core::GUID;
 
@@ -84,23 +85,37 @@ impl SchemaKey {
 ///
 /// Credits: [KrabsETW::schema_locator](https://github.com/microsoft/krabsetw/blob/master/krabs/krabs/schema_locator.hpp).
 /// See also the code of `SchemaKey` for more info
+///
+/// # Thread Safety
+///
+/// `SchemaLocator` is `Sync` by assertion: the schema cache is only ever accessed from
+/// `trace_callback_thunk` (see `src/native/evntrace.rs`), which ETW's `ProcessTrace` guarantees
+/// is called sequentially on a single thread. A `SchemaLocator` is never shared between two
+/// trace sessions, so no two threads can race on the same instance.
+///
+/// `UnsafeCell` is used in place of `Mutex` because the lock was never contended — paying
+/// atomic CAS overhead on every event for a guarantee that ETW already provides externally is
+/// unnecessary.
 #[derive(Default)]
 pub struct SchemaLocator {
-    schemas: Mutex<HashMap<SchemaKey, Arc<Schema>>>,
+    schemas: UnsafeCell<HashMap<SchemaKey, Arc<Schema>>>,
 }
+
+// SAFETY: See the doc comment on `SchemaLocator` above.
+unsafe impl Sync for SchemaLocator {}
 
 impl std::fmt::Debug for SchemaLocator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SchemaLocator")
-            .field("len", &self.schemas.try_lock().map(|guard| guard.len()))
-            .finish()
+        // The schema cache is only safely accessible from the ETW callback thread,
+        // so we do not attempt to read it here.
+        f.debug_struct("SchemaLocator").finish_non_exhaustive()
     }
 }
 
 impl SchemaLocator {
     pub(crate) fn new() -> Self {
         SchemaLocator {
-            schemas: Mutex::new(HashMap::new()),
+            schemas: UnsafeCell::new(HashMap::new()),
         }
     }
 
@@ -120,7 +135,11 @@ impl SchemaLocator {
     pub fn event_schema(&self, event: &EventRecord) -> SchemaResult<Arc<Schema>> {
         let key = SchemaKey::new(event);
 
-        let mut schemas = self.schemas.lock().unwrap();
+        // SAFETY: `event_schema` is only called from `trace_callback_thunk` (see
+        // `src/native/evntrace.rs`). ETW's `ProcessTrace` guarantees all callbacks for a given
+        // session are delivered sequentially on a single thread, so no concurrent access to
+        // this HashMap can occur. See also the `unsafe impl Sync` on `SchemaLocator`.
+        let schemas = unsafe { &mut *self.schemas.get() };
         match schemas.get(&key) {
             Some(s) => Ok(Arc::clone(s)),
             None => {

--- a/src/schema_locator.rs
+++ b/src/schema_locator.rs
@@ -1,8 +1,8 @@
 //! A way to cache and retrieve Schemas
 
 use std::cell::UnsafeCell;
-use std::collections::HashMap;
 use std::sync::Arc;
+use rustc_hash::FxHashMap;
 
 use windows::core::GUID;
 
@@ -98,7 +98,7 @@ impl SchemaKey {
 /// unnecessary.
 #[derive(Default)]
 pub struct SchemaLocator {
-    schemas: UnsafeCell<HashMap<SchemaKey, Arc<Schema>>>,
+    schemas: UnsafeCell<FxHashMap<SchemaKey, Arc<Schema>>>,
 }
 
 // SAFETY: See the doc comment on `SchemaLocator` above.
@@ -115,7 +115,7 @@ impl std::fmt::Debug for SchemaLocator {
 impl SchemaLocator {
     pub(crate) fn new() -> Self {
         SchemaLocator {
-            schemas: UnsafeCell::new(HashMap::new()),
+            schemas: UnsafeCell::new(FxHashMap::default()),
         }
     }
 


### PR DESCRIPTION
I'm writing a modern Rust ETW parsing library, and was doing some parsing benchmarking.
(I've contributed to krabs over the years, and wanted to take a different approach on a few things rather than use ferris).

I was surprised at just how more performant my approach was againt existing approaches so I did a little digging.

It looks like there were a couple of (hopefully) easy lifts that I could share -
  - Borrow property names from schema instead of cloning strings per property lookup
  - Replace `Mutex` with `RefCell` in `Parser` for the per-event property cache (ETW processing is single-threaded)
  - Replace `Mutex` with `UnsafeCell` in `SchemaLocator` for the schema cacheIs 
  - Switch to `FxHashMap` in both `parser.rs` and `schema_locator.rs` - faster hashing for short string
   keys

| Event Type | ferrisetw 1.2.1 | ferrisetw 1.2.0 | krabsetw 4.4.6 | TdhFormatProperty | TdhFormatProperty (naive) | TdhGetProperty |
|--|--:|--:|--:|--:|--:|--:|
| **Process Start** (16 fields) | 1469 ns | 2503 ns | 2522 ns | 541 ns | 1218 ns | 3684 ns |
| **RPC Client Call** (9 fields) | 657 ns | 1213 ns | 771 ns | 338 ns | 481 ns | 1755 ns |
| **Registry CreateKey** (6 fields) | 440 ns | 749 ns | 467 ns | 548 ns | 700 ns | 1577 ns |
| **File Create** (7 fields) | 494 ns | 867 ns | 872 ns | 294 ns | 489 ns | 1146 ns |
| **Thread Start** (10 fields) | 385 ns | 905 ns | 1055 ns | 201 ns | 849 ns | 1482 ns |
* All measurements are per-event averages (ns) over the same captured set of events run on my laptop.

